### PR TITLE
change pypandoc encoding from ascii to utf8 | fixes #131

### DIFF
--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -493,7 +493,7 @@ class VersionDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
         # convert the html to rst
         converted_doc = pypandoc.convert(
             document.rendered_content.encode(
-                'ascii', 'ignore'), 'rst', format='html')
+                'utf8', 'ignore'), 'rst', format='html')
         converted_doc = converted_doc.replace('/media/images/', 'images/')
 
         # prepare the ZIP file


### PR DESCRIPTION
Hi @timlinux In this PR, I've changed pypandoc endocding from `ascii` to `utf8`. Refer to #131.

How do you think? 


Thanks.