### PR TITLE
fixes #147 | 404 landing page

### DIFF
--- a/django_project/base/views/error_views.py
+++ b/django_project/base/views/error_views.py
@@ -22,8 +22,10 @@ def custom_404(request, template_name='404.html'):
     """
     public_projects = Project.objects.filter(approved=True, private=False)
 
-    response = render_to_response(template_name, {
-        'request_path': request.path,
-        'projects': public_projects},context_instance=RequestContext(request))
+    response = render_to_response(
+        template_name, {
+            'request_path': request.path,
+            'projects': public_projects},
+        context_instance=RequestContext(request))
     response.status_code = 404
     return response

--- a/django_project/base/views/error_views.py
+++ b/django_project/base/views/error_views.py
@@ -24,8 +24,6 @@ def custom_404(request, template_name='404.html'):
 
     response = render_to_response(template_name, {
         'request_path': request.path,
-        'projects': public_projects},
-                                  context_instance=RequestContext(request))
+        'projects': public_projects},context_instance=RequestContext(request))
     response.status_code = 404
     return response
-

--- a/django_project/base/views/error_views.py
+++ b/django_project/base/views/error_views.py
@@ -21,7 +21,11 @@ def custom_404(request, template_name='404.html'):
 
     """
     public_projects = Project.objects.filter(approved=True, private=False)
-    return render_to_response(template_name, {
+
+    response = render_to_response(template_name, {
         'request_path': request.path,
-        'projects': public_projects
-    }, context_instance=RequestContext(request))
+        'projects': public_projects},
+                                  context_instance=RequestContext(request))
+    response.status_code = 404
+    return response
+


### PR DESCRIPTION
Hi @timlinux 

After trial and error, its make me confused because everything is running well when debug= `True` but when we change debug=`False` (on production) it will 404 page. 

The problem is `handler404`
I just add 

```
response.status_code = 404
    return response
```

To make sure that the response is only when the status_code = 404.
and now it works well. You can open this link [http://128.199.97.119:61200/](http://128.199.97.119:61200/)

Now, it will automatically redirect on the production. 

![screen shot 2015-12-02 at 1 32 44 pm](https://cloud.githubusercontent.com/assets/2235894/11523976/6f6f1970-98f9-11e5-9d61-7b759af2603a.png)

And the translation it should works too. 

![screen shot 2015-12-02 at 1 34 22 pm](https://cloud.githubusercontent.com/assets/2235894/11523992/86351cb8-98f9-11e5-994a-f326e67474ea.png)


Thanks 