### PR TITLE
Fixing pending items | Fixes #138

### DIFF
--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -19,30 +19,30 @@ logger = logging.getLogger(__name__)
 class ApprovedProjectManager(models.Manager):
     """Custom project manager that shows only approved records."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Query set generator"""
         return super(
-            ApprovedProjectManager, self).get_query_set().filter(
+            ApprovedProjectManager, self).get_queryset().filter(
                 approved=True)
 
 
 class UnapprovedProjectManager(models.Manager):
     """Custom project manager that shows only unapproved records."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Query set generator"""
         return super(
-            UnapprovedProjectManager, self).get_query_set().filter(
+            UnapprovedProjectManager, self).get_queryset().filter(
                 approved=False)
 
 
 class PublicProjectManager(models.Manager):
     """Custom project manager that shows only public and approved projects."""
 
-    def get_query_set(self):
+    def get_queryset(self):
         """Query set generator"""
         return super(
-            PublicProjectManager, self).get_query_set().filter(
+            PublicProjectManager, self).get_queryset().filter(
                 private=False).filter(approved=True)
 
 

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -199,7 +199,7 @@ class PendingProjectListView(
 class ApproveProjectView(StaffuserRequiredMixin, ProjectMixin, RedirectView):
     permanent = False
     query_string = True
-    pattern_name = 'pending-project-list'
+    pattern_name = 'home'
 
     def get_redirect_url(self, slug):
         projects_qs = Project.unapproved_objects.all()


### PR DESCRIPTION
Hi @timlinux 

For the pending items, as I told you before the problem is `def get_query_set` it should `def get_queryset`

I've checked that for the `category`, `version`, `sponsor` I've fixed in previous PR. 

Now, This PR is for the project, I've fixed it. 
and also I changed the redirect url, previous after user approve the project it will be redirected to the pending-items, now it will redirect to home. 

Thanks 