### PR TITLE
Sponsors view test

### DIFF
--- a/django_project/changes/tests/model_factories.py
+++ b/django_project/changes/tests/model_factories.py
@@ -104,5 +104,5 @@ class SponsorshipPeriodF(factory.django.DjangoModelFactory):
     approved = True
     author = factory.SubFactory(UserF)
     project = factory.SubFactory('base.tests.model_factories.ProjectF')
-    sponsor_id = factory.Sequence(lambda n: n)
-    sponsorshiplevel_id = factory.Sequence(lambda n: n)
+    sponsor = factory.SubFactory('changes.tests.model_factories.SponsorF')
+    sponsorshiplevel = factory.SubFactory('changes.tests.model_factories.SponsorshipLevelF')

--- a/django_project/changes/tests/test_models.py
+++ b/django_project/changes/tests/test_models.py
@@ -313,6 +313,17 @@ class TestSponsorshipLevelCRUD(TestCase):
         for key, val in new_model_data.items():
             self.assertEqual(my_model.__dict__.get(key), val)
 
+    def test_SponsorshipLevel_delete(self):
+        """
+        Tests SponsorshipLevel model delete
+        """
+        my_model = SponsorshipLevelF.create()
+
+        my_model.delete()
+
+        # check if deleted
+        self.assertTrue(my_model.pk is None)
+
 
 class TestSponsorshipPeriodCRUD(TestCase):
     """
@@ -363,3 +374,14 @@ class TestSponsorshipPeriodCRUD(TestCase):
         # check if updated
         for key, val in new_model_data.items():
             self.assertEqual(my_model.__dict__.get(key), val)
+
+    def test_SponsorshipPeriod_delete(self):
+        """
+        Tests SponsorshipPeriod model delete
+        """
+        my_model = SponsorshipPeriodF.create()
+
+        my_model.delete()
+
+        # check if deleted
+        self.assertTrue(my_model.pk is None)

--- a/django_project/changes/tests/test_views.py
+++ b/django_project/changes/tests/test_views.py
@@ -5,7 +5,13 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
 from base.tests.model_factories import ProjectF
-from changes.tests.model_factories import CategoryF, EntryF, VersionF
+from changes.tests.model_factories import (
+    CategoryF,
+    EntryF,
+    VersionF,
+    SponsorshipLevelF,
+    SponsorF,
+    SponsorshipPeriodF)
 from core.model_factories import UserF
 import logging
 
@@ -598,5 +604,438 @@ class TestVersionViews(TestCase):
         my_response = self.client.post(reverse('version-delete', kwargs={
             'slug': version_to_delete.slug,
             'project_slug': self.my_version.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+
+class TestSponsorshipLevelViews(TestCase):
+    """Tests that SponsorshipLevel views work."""
+
+    def setUp(self):
+        """
+        Setup before each test
+        We force the locale to en otherwise it will use
+        the locale of the host running the tests and we
+        will get unpredictable results / 404s
+        """
+
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.my_project = ProjectF.create()
+        self.my_sponsorshiplevel = SponsorshipLevelF.create(project=self.my_project)
+        self.my_user = UserF.create(**{
+            'username': 'timlinux',
+            'password': 'password',
+            'is_staff': True
+        })
+
+    def tearDown(self):
+        """
+        Teardown after each test.
+
+        :return:
+        """
+        self.my_project.delete()
+        self.my_sponsorshiplevel.delete()
+        self.my_user.delete()
+
+    def test_SponsorshipLevelListView(self):
+
+        my_response = self.client.get(reverse('sponsorshiplevel-list', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_level/list.html', u'changes/sponsorshiplevel_list.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+        self.assertEqual(my_response.context_data['object_list'][0],
+                         self.my_sponsorshiplevel)
+
+    def test_SponsorshipLevelCreateView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsorshiplevel-create', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_level/create.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipLevelCreateView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsorshiplevel-create', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipLevelCreate_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        post_data = {
+            'name': u'New Test Sponsorship Level',
+            'project': self.my_project.id,
+            'sort_number': 0
+        }
+        my_response = self.client.post(reverse('sponsorshiplevel-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 200)
+
+    def test_SponsorshipLevelCreate_no_login(self):
+
+        post_data = {
+            'name': u'New Test Sponsorship Level'
+        }
+        my_response = self.client.post(reverse('sponsorshiplevel-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipLevelDetailView(self):
+
+        my_response = self.client.get(reverse('sponsorshiplevel-detail', kwargs={
+            'slug': self.my_sponsorshiplevel.slug,
+            'project_slug': self.my_sponsorshiplevel.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_level/detail.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipLevelDeleteView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsorshiplevel-delete', kwargs={
+            'slug': self.my_sponsorshiplevel.slug,
+            'project_slug': self.my_sponsorshiplevel.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_level/delete.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipLevelDeleteView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsorshiplevel-delete', kwargs={
+            'slug': self.my_sponsorshiplevel.slug,
+            'project_slug': self.my_sponsorshiplevel.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipLevelDelete_with_login(self):
+
+        sponsorshiplevel_to_delete = SponsorshipLevelF.create(project=self.my_project)
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.post(reverse('sponsorshiplevel-delete', kwargs={
+            'slug': sponsorshiplevel_to_delete.slug,
+            'project_slug': sponsorshiplevel_to_delete.project.slug
+        }), {})
+        self.assertRedirects(my_response, reverse('sponsorshiplevel-list', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+
+    def test_SponsorshipLevelDelete_no_login(self):
+
+        sponsorshiplevel_to_delete = SponsorshipLevelF.create()
+        my_response = self.client.post(reverse('sponsorshiplevel-delete', kwargs={
+            'slug': sponsorshiplevel_to_delete.slug,
+            'project_slug': self.my_sponsorshiplevel.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+
+class TestSponsorViews(TestCase):
+    """Tests that Sponsor views work."""
+
+    def setUp(self):
+        """
+        Setup before each test
+        We force the locale to en otherwise it will use
+        the locale of the host running the tests and we
+        will get unpredictable results / 404s
+        """
+
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.my_project = ProjectF.create()
+        self.my_sponsor = SponsorF.create(project=self.my_project)
+        self.my_user = UserF.create(**{
+            'username': 'timlinux',
+            'password': 'password',
+            'is_staff': True
+        })
+
+    def tearDown(self):
+        """
+        Teardown after each test.
+
+        :return:
+        """
+        self.my_project.delete()
+        self.my_sponsor.delete()
+        self.my_user.delete()
+
+    def test_SponsorListView(self):
+
+        my_response = self.client.get(reverse('sponsor-list', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+
+    def test_SponsorCreateView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsor-create', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsor/create.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorCreateView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsor-create', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorCreate_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        post_data = {
+            'name': u'New Test Sponsor',
+            'project': self.my_project.id,
+            'sort_number': 0
+        }
+        my_response = self.client.post(reverse('sponsor-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 200)
+
+    def test_SponsorCreate_no_login(self):
+
+        post_data = {
+            'name': u'New Test Sponsor'
+        }
+        my_response = self.client.post(reverse('sponsor-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorDeleteView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsor-delete', kwargs={
+            'slug': self.my_sponsor.slug,
+            'project_slug': self.my_sponsor.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsor/delete.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorDeleteView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsor-delete', kwargs={
+            'slug': self.my_sponsor.slug,
+            'project_slug': self.my_sponsor.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorDelete_with_login(self):
+
+        sponsor_to_delete = SponsorF.create(project=self.my_project)
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.post(reverse('sponsor-delete', kwargs={
+            'slug': sponsor_to_delete.slug,
+            'project_slug': sponsor_to_delete.project.slug
+        }), {})
+        self.assertRedirects(my_response, reverse('sponsor-list', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+
+    def test_SponsorDelete_no_login(self):
+
+        sponsor_to_delete = SponsorF.create()
+        my_response = self.client.post(reverse('sponsor-delete', kwargs={
+            'slug': sponsor_to_delete.slug,
+            'project_slug': self.my_sponsor.project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+
+class TestSponsorshipPeriodViews(TestCase):
+    """Tests that SponsorshipPeriod views work."""
+
+    def setUp(self):
+        """
+        Setup before each test
+
+        We force the locale to en otherwise it will use
+        the locale of the host running the tests and we
+        will get unpredictable results / 404s
+        """
+
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.my_project = ProjectF.create(
+                name='testproject')
+        self.my_sponsor = SponsorF.create(
+                project=self.my_project,
+                name='Kartoza')
+        self.my_sponsorship_level = SponsorshipLevelF.create(
+                project=self.my_project,
+                name='Gold')
+        self.my_sponsorship_period = SponsorshipPeriodF.create(
+            sponsor=self.my_sponsor,
+            sponsorshiplevel=self.my_sponsorship_level,
+            approved=True)
+        self.my_user = UserF.create(**{
+            'username': 'timlinux',
+            'password': 'password',
+            'is_staff': True
+        })
+
+    def tearDown(self):
+        """
+        Teardown after each test.
+
+        :return:
+        """
+        self.my_project.delete()
+        self.my_sponsor.delete()
+        self.my_sponsorship_level.delete()
+        self.my_sponsorship_period.delete()
+        self.my_user.delete()
+
+    def test_SponsorshipPeriodListView(self):
+        """Test SponsorshipPeriod list view."""
+        my_response = self.client.get(reverse('sponsorshipperiod-list', kwargs={
+            'project_slug': self.my_project.slug,
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_period/list.html', u'changes/sponsorshipperiod_list.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipPeriodCreateView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsorshipperiod-create', kwargs={
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_period/create.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipPeriodCreateView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsorshipperiod-create', kwargs={
+            'project_slug': self.my_project.slug,
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipPeriodCreate_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        post_data = {
+            'sponsor': self.my_sponsor.id,
+            'sponsorshiplevel': self.my_sponsorship_level.id,
+            'author': self.my_user.id
+        }
+        my_response = self.client.post(reverse('sponsorshipperiod-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 200)
+
+    def test_SponsorshipPeriodCreate_no_login(self):
+
+        post_data = {
+            'sponsor': self.my_sponsor.id,
+            'sponsorship_level': self.my_sponsorship_level.id
+        }
+        my_response = self.client.post(reverse('sponsorshipperiod-create', kwargs={
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipPeriodUpdateView_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        my_response = self.client.get(reverse('sponsorshipperiod-update', kwargs={
+            'slug': self.my_sponsorship_period.slug,
+            'project_slug': self.my_project.slug
+
+        }))
+        self.assertEqual(my_response.status_code, 200)
+        expected_templates = [
+            'sponsorship_period/update.html'
+        ]
+        self.assertEqual(my_response.template_name, expected_templates)
+
+    def test_SponsorshipPeriodUpdateView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsorshipperiod-update', kwargs={
+            'slug': self.my_sponsorship_period.slug,
+            'project_slug': self.my_project.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipPeriodUpdate_with_login(self):
+
+        self.client.login(username='timlinux', password='password')
+        post_data = {
+            'sponsor': self.my_sponsor.id,
+            'sponsorshiplevel': self.my_sponsorship_level.id,
+            'author': self.my_user.id
+        }
+        my_response = self.client.post(reverse('sponsorshipperiod-update', kwargs={
+            'project_slug': self.my_project.slug,
+            'slug': self.my_sponsorship_period.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 200)
+
+    def test_SponsorshipPeriodUpdate_no_login(self):
+
+        post_data = {
+            'sponsor': self.my_sponsor.id,
+            'sponsorshiplevel': self.my_sponsorship_level.id
+        }
+        my_response = self.client.post(reverse('sponsorshipperiod-update', kwargs={
+            'slug': self.my_sponsorship_period.slug,
+            'project_slug': self.my_project.slug
+        }), post_data)
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipPeriodDeleteView_no_login(self):
+
+        my_response = self.client.get(reverse('sponsorshipperiod-delete', kwargs={
+            'project_slug': self.my_project.slug,
+            'slug': self.my_sponsorship_period.slug
+        }))
+        self.assertEqual(my_response.status_code, 302)
+
+    def test_SponsorshipPeriodDelete_no_login(self):
+
+        my_response = self.client.post(reverse('sponsorshipperiod-delete', kwargs={
+            'project_slug': self.my_project.slug,
+            'slug': self.my_sponsorship_period.slug
         }))
         self.assertEqual(my_response.status_code, 302)

--- a/django_project/changes/views/sponsor.py
+++ b/django_project/changes/views/sponsor.py
@@ -109,19 +109,6 @@ class JSONSponsorListView(SponsorMixin, JSONResponseMixin, ListView):
         """
         return self.render_to_json_response(context, **response_kwargs)
 
-    def get_queryset(self):
-        """Get the queryset for this view.
-
-        :returns: A queryset which is filtered to only show approved Sponsors
-        of project.
-        :rtype: QuerySet
-        :raises: Http404
-        """
-        sponsor_id = self.kwargs['sponsor']
-        sponsor = get_object_or_404(Sponsor, id=sponsor_id)
-        qs = Sponsor.approved_objects.filter(project=sponsor.project)
-        return qs
-
 
 class SponsorListView(SponsorMixin, PaginationMixin, ListView):
     """List view for Sponsor."""

--- a/django_project/changes/views/sponsorship_level.py
+++ b/django_project/changes/views/sponsorship_level.py
@@ -27,8 +27,7 @@ from ..forms import SponsorshipLevelForm
 class JSONResponseMixin(object):
     """A mixin that can be used to render a JSON response."""
     def render_to_json_response(self, context, **response_kwargs):
-        """Returns a JSON response, transforming
-        'context' to make the payload.
+        """Returns a JSON response, transforming 'context' to make the payload.
 
         :param context: Context data to use with template
         :type context: dict
@@ -59,28 +58,21 @@ class JSONResponseMixin(object):
         for sponsorshiplevel in context['sponsorshiplevels']:
             if not first_flag:
                 result += ',\n'
-            result += '    "%s" : "%s"' % (
-                sponsorshiplevel.id,
-                sponsorshiplevel.name
-            )
+            result += '    "%s" : "%s"' % (sponsorshiplevel.id, sponsorshiplevel.name)
             first_flag = False
         result += '\n}'
         return result
 
 
 class SponsorshipLevelMixin(object):
-    """Mixin class to provide standard settings for Sponsorship level."""
+    """Mixin class to provide standard settings for SponsorshipLevel."""
     model = SponsorshipLevel
     form_class = SponsorshipLevelForm
 
 
-class JSONSponsorshipLevelListView(
-        SponsorshipLevel,
-        JSONResponseMixin,
-        ListView):
-    """List view for Sponsorship Level as json object
-    - needed by javascript."""
-    context_object_name = 'sponsorshiplevel'
+class JSONSponsorshipLevelListView(SponsorshipLevelMixin, JSONResponseMixin, ListView):
+    """List view for sponsorship level as json object - needed by javascript."""
+    context_object_name = 'sponsorshiplevels'
 
     def dispatch(self, request, *args, **kwargs):
         """Ensure this view is only used via ajax.
@@ -100,7 +92,7 @@ class JSONSponsorshipLevelListView(
             request, *args, **kwargs)
 
     def render_to_response(self, context, **response_kwargs):
-        """Render this Sponsorship level as markdown.
+        """Render this version as markdown.
 
         :param context: Context data to use with template.
         :type context: dict
@@ -112,21 +104,6 @@ class JSONSponsorshipLevelListView(
         :rtype: HttpResponse
         """
         return self.render_to_json_response(context, **response_kwargs)
-
-    def get_queryset(self):
-        """Get the queryset for this view.
-
-        :returns: A queryset which is filtered to only show approved Sponsors
-        of project.
-        :rtype: QuerySet
-        :raises: Http404
-        """
-        sponsorshiplevel_id = self.kwargs['sponsorshiplevel']
-        sponsorshiplevel = get_object_or_404(
-                SponsorshipLevel, id=sponsorshiplevel_id)
-        qs = SponsorshipLevel.approved_objects.filter(
-                project=sponsorshiplevel.project)
-        return qs
 
 
 class SponsorshipLevelListView(

--- a/django_project/changes/views/sponsorship_period.py
+++ b/django_project/changes/views/sponsorship_period.py
@@ -74,12 +74,12 @@ class SponsorshipPeriodMixin(object):
 
 
 class JSONSponsorshipPeriodListView(
-        SponsorshipPeriod,
+        SponsorshipPeriodMixin,
         JSONResponseMixin,
         ListView):
     """List view for Sponsorship Period as json object
      - needed by javascript."""
-    context_object_name = 'sponsorshipperiod'
+    context_object_name = 'sponsorshipperiods'
 
     def dispatch(self, request, *args, **kwargs):
         """Ensure this view is only used via ajax.
@@ -111,21 +111,6 @@ class JSONSponsorshipPeriodListView(
         :rtype: HttpResponse
         """
         return self.render_to_json_response(context, **response_kwargs)
-
-    def get_queryset(self):
-        """Get the queryset for this view.
-
-        :returns: A queryset which is filtered to only show approved Sponsors
-        of project.
-        :rtype: QuerySet
-        :raises: Http404
-        """
-        sponsorshipperiod_id = self.kwargs['sponsorshipperiod']
-        sponsorshipperiod = get_object_or_404(
-                SponsorshipPeriod, id=sponsorshipperiod_id)
-        qs = SponsorshipPeriod.approved_objects.filter(
-                project=sponsorshipperiod.project)
-        return qs
 
 
 class SponsorshipPeriodListView(


### PR DESCRIPTION
Hi @timlinux 
In this PR, I've added some view tests for the sponsors stuff and all tests have been passed. 

btw, did you try my previous PR within your machine? 
I am bit confused for the error. 
I've tried many times with new docker containers and in my ubuntu server too, and it works well. 

The code is like this:


```
def current_sponsor(self):
        today = timezone.now()
        end = self.end_date
        if end < today:
            return False
```
end_date model 
```
end_date = models.DateField(
        _("End date"),
        help_text='End date of sponsorship period',
        default=timezone.now)
```

As my understanding, it should works. If I use `datetime` it will produce error ` can't subtract offset-naive and offset-aware datetimes`. So we have to replace `tzinfo` like in [this solution](http://stackoverflow.com/questions/4530069/python-how-to-get-a-value-of-datetime-today-that-is-timezone-aware). But that solution does not work in kartoza production even it works well in my machine. 

thanks. 
