### PR TITLE
Hide pending and management menu from non staff 

### DIFF
--- a/deployment/docker/REQUIREMENTS-dev.txt
+++ b/deployment/docker/REQUIREMENTS-dev.txt
@@ -2,7 +2,7 @@ django-nose
 coverage
 pep8>=1.5.7,<1.6
 pylint
-flake8
+flake8==2.5.4
 factory_boy
 
 django-devserver

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -35,9 +35,13 @@
         {% if unapproved %}
             <h3>All sponsors are approved.</h3>
         {% else %}
-            <h3>No sponsors are defined, but you can <a
-                    class="btn btn-default btn-mini"
-                    href='{% url "sponsor-create" project_slug %}'>create one</a>.</h3>
+            {% if user.is_staff %}
+                <h3>No sponsors are defined, but you can <a
+                        class="btn btn-default btn-mini"
+                        href='{% url "sponsor-create" project_slug %}'>create one</a>.</h3>
+            {% else %}
+                <h3>No sponsors are defined</h3>
+            {% endif %}
         {% endif %}
     {% endifequal %}
 

--- a/django_project/changes/templates/sponsorship_level/detail.html
+++ b/django_project/changes/templates/sponsorship_level/detail.html
@@ -16,6 +16,7 @@
     <div class="col-lg-10">
       <h3>{{ sponsorshiplevel.name }}</h3>
     </div>
+    {% if user.is_staff %}
     <div class="col-lg-2">
       <div class="btn-group">
         <a class="btn btn-default btn-sm tooltip-toggle"
@@ -30,6 +31,7 @@
         </a>
       </div>
     </div>
+    {% endif %}
   </div>
   <div class="row">
     <div class="col-lg-8">

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -15,7 +15,7 @@
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
             Sponsorship Levels
-           {% if user.is_authenticated %}
+           {% if user.is_staff %}
                 <div class="pull-right btn-group">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsorshiplevel-create" project_slug %}'
@@ -66,15 +66,15 @@
                            href='{% url "sponsorshiplevel-approve" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
                             <span class="glyphicon glyphicon-thumbs-up"></span>
                         </a>
+                        <a class="btn btn-default btn-mini"
+                           href='{% url "sponsorshiplevel-delete" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
+                            <span class="glyphicon glyphicon-minus"></span>
+                        </a>
+                        <a class="btn btn-default btn-mini"
+                           href='{% url "sponsorshiplevel-update" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
+                            <span class="glyphicon glyphicon-pencil"></span>
+                        </a>
                     {% endif %}
-                    <a class="btn btn-default btn-mini"
-                       href='{% url "sponsorshiplevel-delete" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
-                        <span class="glyphicon glyphicon-minus"></span>
-                    </a>
-                    <a class="btn btn-default btn-mini"
-                       href='{% url "sponsorshiplevel-update" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
-                        <span class="glyphicon glyphicon-pencil"></span>
-                    </a>
                     <a class="btn btn-default btn-mini"
                        href='{% url "sponsorshiplevel-detail" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
                         <span class="glyphicon glyphicon-eye-open"></span>

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -70,15 +70,15 @@
                            href='{% url "sponsorshipperiod-approve" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
                             <span class="glyphicon glyphicon-thumbs-up"></span>
                         </a>
+                        <a class="btn btn-default btn-mini"
+                           href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                            <span class="glyphicon glyphicon-minus"></span>
+                        </a>
+                        <a class="btn btn-default btn-mini"
+                           href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                            <span class="glyphicon glyphicon-pencil"></span>
+                        </a>
                     {% endif %}
-                    <a class="btn btn-default btn-mini"
-                       href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                        <span class="glyphicon glyphicon-minus"></span>
-                    </a>
-                    <a class="btn btn-default btn-mini"
-                       href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                        <span class="glyphicon glyphicon-pencil"></span>
-                    </a>
                     <a class="btn btn-default btn-mini"
                        href='{% url "sponsorshipperiod-detail" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
                         <span class="glyphicon glyphicon-eye-open"></span>

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -34,6 +34,14 @@
 
         </li>
     </ul>
+     <ul class="nav navbar-nav">
+        <li>
+            <a href="{% url 'committee-list' the_project.slug %}">
+                Teams
+            </a>
+    </li>
+    </ul>
+    {% if user.is_staff %}
     <ul class="nav navbar-nav">
         <li>
             <a href="{% url "version-create" the_project.slug %}" class="dropdown-toggle" data-toggle="dropdown">
@@ -45,6 +53,7 @@
                 <li><a href="{% url 'version-list' the_project.slug %}">Versions</a></li>
             </ul>
     </li>
+    {% endif %}
     </ul>
     <ul class="nav navbar-nav">
         <li>
@@ -53,17 +62,12 @@
             </a>
             <ul class="dropdown-menu">
                 <li><a href="{% url 'sponsor-list' the_project.slug %}">Sponsors</a></li>
-                <li><a href="{% url 'sponsorshiplevel-list' the_project.slug %}">Sponsor Levels</a></li>
-                <li><a href="{% url 'sponsorshipperiod-list' the_project.slug %}">Sponsor Periods</a></li>
+                {% if user.is_authenticated %}
+                    <li><a href="{% url 'sponsorshiplevel-list' the_project.slug %}">Sponsor Levels</a></li>
+                    <li><a href="{% url 'sponsorshipperiod-list' the_project.slug %}">Sponsor Periods</a></li>
+                {% endif %}
                 <li><a href="{% url 'sponsor-world-map' the_project.slug %}">Sponsors Map</a></li>
             </ul>
-    </li>
-    </ul>
-    <ul class="nav navbar-nav">
-        <li>
-            <a href="{% url 'committee-list' the_project.slug %}">
-                Committees
-            </a>
     </li>
     </ul>
 

--- a/django_project/core/base_templates/includes/right-nav.html
+++ b/django_project/core/base_templates/includes/right-nav.html
@@ -6,6 +6,7 @@
         </a>
     </li>
 {% endif %}
+{% if user.is_authenticated %}
 <li>
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <b class="caret"></b> Pending Approval
@@ -23,6 +24,7 @@
         {% endif %}
     </ul>
 </li>
+{% endif %}
 <li class="dropdown">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <b class="caret"></b> Account

--- a/django_project/vota/templates/committee/list.html
+++ b/django_project/vota/templates/committee/list.html
@@ -2,19 +2,19 @@
 {% load thumbnail %}
 {% load staticfiles %}
 
-{% block title %}Committees - {{ block.super }}{% endblock %}
+{% block title %}Teams - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-    <h1>Committees</h1>
+    <h1>Teams</h1>
 {% endblock page_title %}
 
 {% block content %}
     <div class="page-header">
         <h1 class="text-muted">
-            Committees
+            Teams
             <div class="pull-right btn-group">
                 {% if user.is_authenticated and committees %}
                     <a class="btn btn-default btn-mini tooltip-toggle"


### PR DESCRIPTION
Issue #295

- [x] Don't show pending approval to non logged in users.
- [x] All users should be able to view the sponsors list and maps
- [x] Changelogs menu should be staff only
- [x] Committees menu should move just to the right of the project name, left of the changelogs. Probably nicer to call it teams.
- [x] Sponsor management should only be available for staff users
- [ ]  Non staff users should see only entries pending approval menu item if they themselves have authored entries which are pending approval
