### PR TITLE
Added "add new version" when version is empty

### DIFF
--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -43,7 +43,9 @@
         {% if unapproved %}
             <h3>All versions are approved.</h3>
         {% else %}
-            <h3>No versions are defined, but you can create one.</h3>
+            <h3>No versions are defined, but you can <a
+                    class="btn btn-default btn-mini"
+                    href='{% url "version-create" project_slug %}'>create one</a>.</h3>
         {% endif %}
     {%  endifequal %}
     {% for version in versions %}

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -61,6 +61,10 @@ class VersionListView(VersionMixin, PaginationMixin, ListView):
         context['num_versions'] = self.get_queryset().count()
         context['unapproved'] = False
         context['rst_download'] = False
+        project_slug = self.kwargs.get('project_slug', None)
+        context['project_slug'] = project_slug
+        if project_slug:
+            context['the_project'] = Project.objects.get(slug=project_slug)
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
Hi @timlinux  this PR based on Issue #298 

Now we are able to add version when the version is empty. 


![screen shot 2016-06-20 at 11 55 15 am](https://cloud.githubusercontent.com/assets/2235894/16183624/4a94b0a0-36de-11e6-814e-9166886e5bd8.png)
