### PR TITLE
Added sponsor list download as html

### DIFF
--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -16,6 +16,11 @@
     <div class="row" style="margin-top:15px;margin-bottom:15px;">
         <div class="col-lg-12">
             <div class="btn-group btn-group pull-left">
+            <a class="btn btn-default btn-mini tooltip-toggle"
+                   data-title="Download sponsor list as html"
+                   href='{% url 'version-sponsor-download' project_slug=version.project.slug slug=version.slug %}'>
+                    <span class="glyphicon glyphicon-download"></span>
+                </a>
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Download as RST"
                    href='{% url 'version-download' project_slug=version.project.slug slug=version.slug %}'>

--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -32,6 +32,7 @@ from views import (
     ApproveVersionView,
     VersionDownload,
     VersionDownloadGnu,
+    VersionSponsorDownload,
     # Entry
     EntryDetailView,
     EntryDeleteView,
@@ -144,6 +145,9 @@ urlpatterns = patterns(
     url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/gnu/$',
         view=VersionDownloadGnu.as_view(),
         name='version-download-gnu'),
+    url(regex='^(?P<project_slug>[\w-]+)/version/(?P<slug>[\w.-]+)/downloadsponsor/$',
+        view=VersionSponsorDownload.as_view(),
+        name='version-sponsor-download'),
 
     # Changelog entry management
     url(regex='^(?P<project_slug>[\w-]+)/(?P<version_slug>[\w.-]+)/'

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -672,6 +672,7 @@ class VersionDownloadGnu(VersionMixin, DetailView):
             context,
             content_type="text/plain; charset=utf-8")
 
+
 class VersionSponsorDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
     """View to allow staff users to download Version page in html format"""
     template_name = 'version/includes/version-sponsors.html'
@@ -732,7 +733,7 @@ class VersionSponsorDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
 
         # grab all of the images from document
         images = []
-        page = BeautifulSoup(document,'html.parser')
+        page = BeautifulSoup(document, 'html.parser')
         pages = page.findAll('img')
         for image in pages:
             img = image['src']


### PR DESCRIPTION
This PR is for #290 
Hi @timlinux 

How about this one? 

The result is like this file ->
[QGIS-Sponsor-2.14.0.zip](https://github.com/kartoza/projecta/files/330925/QGIS-Sponsor-2.14.0.zip)

![screen shot 2016-06-24 at 4 09 51 am](https://cloud.githubusercontent.com/assets/2235894/16322025/9c05318c-39ca-11e6-9b76-983079cead8f.png)

The result of files after extracted. 
![screen shot 2016-06-24 at 4 10 29 am](https://cloud.githubusercontent.com/assets/2235894/16322046/bf043e8a-39ca-11e6-8b43-420e689cff4f.png)

If I open in web browser
![screen shot 2016-06-24 at 4 11 16 am](https://cloud.githubusercontent.com/assets/2235894/16322055/ce90f29e-39ca-11e6-85b0-e8e38197efc3.png)
