### PR TITLE
Fixed Edit for sponsorship period and sponsorship level

### DIFF
--- a/django_project/changes/templates/sponsorship_period/delete.html
+++ b/django_project/changes/templates/sponsorship_period/delete.html
@@ -34,7 +34,7 @@
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <h3>Sponsorship Period: {{ sponsorshipperiod.project }}</h3>
+        <h3>Sponsorship Period: {{ sponsorshipperiod.project }} | {{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.start_date }}, {{ sponsorshipperiod.end_date }}</h3>
       </div>
     </div>
   </form>

--- a/django_project/changes/templates/sponsorship_period/detail.html
+++ b/django_project/changes/templates/sponsorship_period/detail.html
@@ -19,12 +19,12 @@
     <div class="col-lg-2">
       <div class="btn-group">
         <a class="btn btn-default btn-sm tooltip-toggle"
-           href='{% url "sponsorshiplevel-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'
+           href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'
            data-title="Delete {{ sponsorshipperiod.project.name }}">
           <span class="glyphicon glyphicon-minus"></span>
         </a>
         <a class="btn btn-default btn-sm tooltip-toggle"
-           href='{% url "sponsorshiplevel-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'
+           href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'
            data-title="Edit {{ sponsorshipperiod.project.name }}">
           <span class="glyphicon glyphicon-pencil"></span>
         </a>
@@ -33,7 +33,7 @@
   </div>
   <div class="row">
     <div class="col-lg-8">
-          Sponsorship Level : {{ sponsorshipperiod.sponsorshiplevel }}<br/>
+          Sponsorship Level : {{ sponsorshipperiod.sponsorship_level }}<br/>
           Start Date : {{ sponsorshipperiod.start_date }}<br/>
           End Date : {{ sponsorshipperiod.end_date }}<br/>
         {% if sponsorshipperiod.sponsorshiplevel.logo %}

--- a/django_project/changes/views/sponsorship_level.py
+++ b/django_project/changes/views/sponsorship_level.py
@@ -354,21 +354,6 @@ class SponsorshipLevelUpdateView(
     context_object_name = 'sponsorshiplevel'
     template_name = 'sponsorship_level/update.html'
 
-    def get_form_kwargs(self):
-        """Get keyword arguments from form.
-
-        :returns keyword argument from the form
-        :rtype: dict
-        """
-        kwargs = super(SponsorshipLevelUpdateView, self).get_form_kwargs()
-        self.project_slug = self.kwargs.get('project_slug', None)
-        self.project = Project.objects.get(slug=self.project_slug)
-        kwargs.update({
-            'user': self.request.user,
-            'project': self.project
-        })
-        return kwargs
-
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.
 
@@ -384,6 +369,27 @@ class SponsorshipLevelUpdateView(
         context['sponsorshiplevels'] = self.get_queryset() \
             .filter(project=self.project)
         return context
+
+    def get_form_kwargs(self):
+        """Get keyword arguments from form.
+
+        :returns keyword argument from the form
+        :rtype: dict
+        """
+        kwargs = super(SponsorshipLevelUpdateView, self).get_form_kwargs()
+        sponsor_level_slug = self.kwargs.get('slug', None)
+        self.sponsorlevel = SponsorshipLevel.objects.get(slug=sponsor_level_slug)
+        self.project_slug = self.kwargs.get('project_slug', None)
+        self.project = Project.objects.get(slug=self.project_slug)
+
+        kwargs.update({
+            'user': self.request.user,
+            'instance': self.sponsorlevel,
+            'project': self.project
+        })
+        return kwargs
+
+
 
     def get_queryset(self):
         """Get the queryset for this view.

--- a/django_project/changes/views/sponsorship_period.py
+++ b/django_project/changes/views/sponsorship_period.py
@@ -229,7 +229,9 @@ class SponsorshipPeriodDeleteView(
         :rtype: HttpResponse
         """
         self.project_slug = self.kwargs.get('project_slug', None)
+        self.sponsor_period_slug = self.kwargs.get('slug', None)
         self.project = Project.objects.get(slug=self.project_slug)
+        self.sponsorperiod = SponsorshipPeriod.objects.get(slug=self.sponsor_period_slug)
         return super(
                 SponsorshipPeriodDeleteView,
                 self).get(request, *args, **kwargs)
@@ -370,10 +372,13 @@ class SponsorshipPeriodUpdateView(
         kwargs = super(
                 SponsorshipPeriodUpdateView,
                 self).get_form_kwargs()
+        sponsor_period_slug = self.kwargs.get('slug', None)
+        self.sponsorperiod = SponsorshipPeriod.objects.get(slug=sponsor_period_slug)
         self.project_slug = self.kwargs.get('project_slug', None)
         self.project = Project.objects.get(slug=self.project_slug)
         kwargs.update({
             'user': self.request.user,
+            'instance': self.sponsorperiod,
             'project': self.project
         })
         return kwargs


### PR DESCRIPTION
Hi Tim, 

This PR for #304 
There is also some fixing after I checked. 

These are the screenshoot:

Update sponsorship period:
![screen shot 2016-06-28 at 1 59 40 am](https://cloud.githubusercontent.com/assets/2235894/16395250/2234e50c-3ce3-11e6-85d6-43cd2a97e0cb.png)

Adding more information on the delete confirmation page of sponsorship period: 
![screen shot 2016-06-28 at 2 17 14 am](https://cloud.githubusercontent.com/assets/2235894/16395251/226c472c-3ce3-11e6-8ed7-3419cad07e4d.png)

Update sponsorship level:
![screen shot 2016-06-28 at 2 18 43 am](https://cloud.githubusercontent.com/assets/2235894/16395252/23bf66ae-3ce3-11e6-9299-26d940dea408.png)

I have tried to update and delete from both of features and all work. 

Thanks 