### PR TITLE
Cleanup navbar and buttons

### DIFF
--- a/django_project/base/templates/button_span.html
+++ b/django_project/base/templates/button_span.html
@@ -1,0 +1,1 @@
+<span class="{{ button_icon }}"></span>

--- a/django_project/base/templates/project/detail.html
+++ b/django_project/base/templates/project/detail.html
@@ -38,7 +38,7 @@
               <a class="btn btn-default btn-mini tooltip-toggle"
                   href='{% url "version-create" versions.0.project.slug %}'
                   data-title="Create New Version">
-                <span class="glyphicon glyphicon-asterisk"></span>
+                {% show_button_icon "add" %}
               </a>
             {% endif %}
           </div>

--- a/django_project/base/templates/project/includes/project-panel.html
+++ b/django_project/base/templates/project/includes/project-panel.html
@@ -48,7 +48,7 @@
         <a href="{% url 'version-create' project_slug=project.slug %}"
            class="btn btn-default pull-right btn-sm tooltip-toggle"
            data-title="Create New Version">
-          <span class="glyphicon glyphicon-asterisk"></span>
+          {% show_button_icon "add" %}
         </a>
       </h4>
       <hr/>

--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -1,5 +1,5 @@
 {% extends "project_base.html" %}
-
+{% load custom_markup %}
 {% load i18n %}
 
 {% block title %}Projects{% endblock %}
@@ -25,7 +25,7 @@
             <a class="btn btn-default tooltip-toggle"
                 href='{% url "project-create" %}'
                 data-title="Start New Project">
-                <span class="glyphicon glyphicon-asterisk"></span>
+                {% show_button_icon "add" %}
             </a>
             <a class="btn btn-default tooltip-toggle"
                href='{% url "pending-project-list" %}'

--- a/django_project/base/templatetags/custom_markup.py
+++ b/django_project/base/templatetags/custom_markup.py
@@ -22,3 +22,17 @@ def base_markdown(value):
 @stringfilter
 def is_gif(value):
     return value[-4:] == '.gif'
+
+
+@register.inclusion_tag('button_span.html', takes_context=True)
+def show_button_icon(context, value):
+
+    context_icon = {
+        'add': 'glyphicon glyphicon-asterisk',
+        'update': 'glyphicon glyphicon-pencil',
+        'delete': 'glyphicon glyphicon-minus'
+    }
+
+    return {
+        'button_icon': context_icon[value]
+    }

--- a/django_project/changes/templates/category/list.html
+++ b/django_project/changes/templates/category/list.html
@@ -1,5 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
+{% load custom_markup %}
 
 {% block title %}Categories - {{ block.super }}{% endblock %}
 
@@ -20,7 +21,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "category-create" project_slug %}'
                        data-title="Create New Category">
-                        <span class="glyphicon glyphicon-asterisk"></span>
+                        {% show_button_icon "add" %}
                     </a>
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/entry/list.html
+++ b/django_project/changes/templates/entry/list.html
@@ -21,7 +21,7 @@
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Add Entry"
                    href='{% url "entry-create" project_slug=project_slug version_slug=version_slug %}'>
-                    <span class="glyphicon glyphicon-asterisk"></span>
+                    {% show_button_icon "add" %}
                 </a>
                 {% if not unapproved %}
                     <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/entry/pending-list.html
+++ b/django_project/changes/templates/entry/pending-list.html
@@ -21,7 +21,7 @@
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Add Entry"
                    href='{% url "entry-create" project_slug=entries.0.version.project.slug version_slug=entries.0.version.slug %}'>
-                    <span class="glyphicon glyphicon-asterisk"></span>
+                    {% show_button_icon "add" %}
                 </a>
             </small>
         </h1>

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -1,6 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
-
+{% load custom_markup %}
 {% block title %}Sponsors - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -19,7 +19,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsor-create" project_slug %}'
                        data-title="Create New Sponsor">
-                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                        {% show_button_icon "add" %}
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsor-list" project_slug %}'

--- a/django_project/changes/templates/sponsor/pending-list.html
+++ b/django_project/changes/templates/sponsor/pending-list.html
@@ -1,6 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
-
+{% load custom_markup %}
 {% block title %}Sponsors - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsor-create" project_slug %}'
                        data-title="Create New Sponsor">
-                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                        {% show_button_icon "add" %}
 
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -1,6 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
-
+{% load custom_markup %}
 {% block title %}Sponsorship Levels - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsorshiplevel-create" project_slug %}'
                        data-title="Create New Sponsorship Level">
-                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                        {% show_button_icon "add" %}
 
                         {% if not unapproved %}
                             <a class="btn btn-default btn-mini tooltip-toggle"
@@ -68,11 +68,11 @@
                         </a>
                         <a class="btn btn-default btn-mini"
                            href='{% url "sponsorshiplevel-delete" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
-                            <span class="glyphicon glyphicon-minus"></span>
+                            {% show_button_icon "delete" %}
                         </a>
                         <a class="btn btn-default btn-mini"
                            href='{% url "sponsorshiplevel-update" project_slug=sponsorshiplevel.project.slug slug=sponsorshiplevel.slug %}'>
-                            <span class="glyphicon glyphicon-pencil"></span>
+                            {% show_button_icon "update" %}
                         </a>
                     {% endif %}
                     <a class="btn btn-default btn-mini"

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -1,6 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
-
+{% load custom_markup %}
 {% block title %}Sponsorship Periods - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsorshipperiod-create" project_slug %}'
                        data-title="Create New sponsorship period">
-                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                        {% show_button_icon "add" %}
                         {% if not unapproved %}
                             <a class="btn btn-default btn-mini tooltip-toggle"
                                href='{% url "pending-sponsorshipperiod-list" project_slug %}'
@@ -72,11 +72,11 @@
                         </a>
                         <a class="btn btn-default btn-mini"
                            href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                            <span class="glyphicon glyphicon-minus"></span>
+                            {% show_button_icon "delete" %}
                         </a>
                         <a class="btn btn-default btn-mini"
                            href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                            <span class="glyphicon glyphicon-pencil"></span>
+                            {% show_button_icon "update" %}
                         </a>
                     {% endif %}
                     <a class="btn btn-default btn-mini"

--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -1,4 +1,5 @@
 {% extends "project_base.html" %}
+{% load custom_markup %}
 {% load staticfiles %}
 {% load disqus_tags %}
 
@@ -30,21 +31,21 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        data-title="Delete Version"
                        href='{% url "version-delete" project_slug=version.project.slug slug=version.slug %}'>
-                        <span class="glyphicon glyphicon-minus"></span>
+                        {% show_button_icon "delete" %}
                     </a>
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        data-title="Update Version"
                        href='{% url "version-update" project_slug=version.project.slug slug=version.slug %}'>
-                        <span class="glyphicon glyphicon-pencil"></span>
+                        {% show_button_icon "update" %}
                     </a>
                 {% endif %}
             </div>
             <div class="pull-right">
                 {% if user.is_authenticated %}
-                    <a href="{% url 'entry-create' project_slug=version.project.slug version_slug=version.slug %}"
-                       class="btn btn-default tooltip-toggle"
-                       data-title="Add New Entry">
-                        <span class="glyphicon glyphicon-plus"></span>
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       data-title="Update Version"
+                       href='{% url "version-update" project_slug=version.project.slug slug=version.slug %}'>
+                        {% show_button_icon "add" %}
                     </a>
                 {% endif %}
                 <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -1,7 +1,7 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
 {% load staticfiles %}
-
+{% load custom_markup %}
 {% block title %}Versions - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -21,7 +21,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "version-create" versions.0.project.slug %}'
                        data-title="Create New Version">
-                        <span class="glyphicon glyphicon-asterisk"></span>
+                        {% show_button_icon "add" %}
                     </a>
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "pending-version-list" versions.0.project.slug %}'

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -24,11 +24,14 @@
 {% else %}
     <ul class="nav navbar-nav">
         {% if the_project.image_file %}
-            <li><img class="img-rounded"
-                     src="{% thumbnail the_project.image_file 50x50 crop %}"/></li>
+            <li><a href="{% url "project-detail" the_project.slug %}" style="padding: 0;">
+                <img class="img-rounded"
+                     src="{% thumbnail the_project.image_file 50x50 crop %}"/>
+                </a>
+            </li>
         {% endif %}
         <li>
-            <a class="nav navbar-nav" >
+            <a href="{% url "project-detail" the_project.slug %}" class="nav navbar-nav" >
                 {{ the_project.name }}
             </a>
 
@@ -45,7 +48,7 @@
     <ul class="nav navbar-nav">
         <li>
             <a href="{% url "version-create" the_project.slug %}" class="dropdown-toggle" data-toggle="dropdown">
-                Changelogs <b class="caret"></b>
+                Changelog <b class="caret"></b>
             </a>
             </a>
             <ul class="dropdown-menu">
@@ -82,31 +85,6 @@
         <li>
             <a href="{% url 'ballot-create' the_project.slug the_committee.slug %}">
                 Start Ballot
-            </a>
-        </li>
-    </ul>
-{% endif %}
-{% if the_version and the_project %}
-    <ul class="nav navbar-nav">
-        <li>
-            {% if not as_thumbs %}
-                <a href="{% url 'version-thumbs' the_project.slug the_version.slug %}">
-                    Version Thumbnails
-                </a>
-            {% else %}
-                <a href="{% url 'version-detail' the_project.slug the_version.slug %}">
-                    Version as List
-                </a>
-            {% endif %}
-        </li>
-        <li>
-            <a href="{% url 'entry-list' the_project.slug the_version.slug %}">
-                Version Entries
-            </a>
-        </li>
-        <li>
-            <a href="{% url 'entry-create' the_project.slug the_version.slug %}">
-                Add Entry
             </a>
         </li>
     </ul>

--- a/django_project/vota/templates/ballot/list.html
+++ b/django_project/vota/templates/ballot/list.html
@@ -1,6 +1,6 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
-
+{% load custom_markup %}
 {% block title %}Ballots - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -19,7 +19,7 @@
                 <small class="pull-right">
                     <a class="btn btn-default btn-mini"
                        href='{% url "ballot-create" project_slug=committee.project.slug committee_slug=committee.slug %}'>
-                        <span class="glyphicon glyphicon-asterisk"></span>
+                       {% show_button_icon "add" %}
                     </a>
                 </small>
             {% endif %}

--- a/django_project/vota/templates/committee/includes/committee-panel.html
+++ b/django_project/vota/templates/committee/includes/committee-panel.html
@@ -23,7 +23,7 @@
                     <a href="{% url 'ballot-create' project_slug=committee.project.slug committee_slug=committee.slug %}"
                        class="btn btn-default btn-xs tooltip-toggle"
                        data-title="Create New Ballot">
-                        <span class="glyphicon glyphicon-asterisk"></span>
+                        {% show_button_icon "add" %}
                     </a>
                 </div>
             </h4>

--- a/django_project/vota/templates/committee/list.html
+++ b/django_project/vota/templates/committee/list.html
@@ -1,7 +1,7 @@
 {% extends "project_base.html" %}
 {% load thumbnail %}
 {% load staticfiles %}
-
+{% load custom_markup %}
 {% block title %}Teams - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "committee-create" committees.0.project.slug %}'
                        data-title="Create New Version">
-                        <span class="glyphicon glyphicon-asterisk"></span>
+                        {% show_button_icon "add" %}
                     </a>
                 {% endif %}
             </div>


### PR DESCRIPTION
Fix #306, #308, #99 

- [x]  Make project icon and name clickable - click should take you to e.g. /en/qgis/
- [x] Changelogs -> Changelog
- [x] Remove version entries item
- [x] Remove version thumbnails item
- [x] Remove add entry item
- [x] Version page add entry icon should be the star icon for consistency
- [x] We should have a standardised, easily updatable visual style throughout the site.