### PR TITLE
Fixed issue 303 Sponsorship periods view

### DIFF
--- a/django_project/changes/models/sponsorship_period.py
+++ b/django_project/changes/models/sponsorship_period.py
@@ -81,7 +81,7 @@ class SponsorshipPeriod(models.Model):
             ('project', 'slug')
         )
         app_label = 'changes'
-        ordering = ['start_date']
+        ordering = ['-end_date']
 
     def save(self, *args, **kwargs):
 

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -19,15 +19,16 @@
                 <div class="pull-right btn-group">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsorshipperiod-create" project_slug %}'
-                       data-title="Create New sponsorship period"> </a>
-                        {% show_button_icon "add" %}
-                        {% if not unapproved %}
-                            <a class="btn btn-default btn-mini tooltip-toggle"
-                               href='{% url "pending-sponsorshipperiod-list" project_slug %}'
-                               data-title="View Pending sponsorship period">
-                                <span class="glyphicon glyphicon-time"></span>
-                            </a>
-                        {% endif %}
+                       data-title="Create New sponsorship period">
+                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                    {% if not unapproved %}
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                           href='{% url "pending-sponsorshipperiod-list" project_slug %}'
+                           data-title="View Pending sponsorship period">
+                            <span class="glyphicon glyphicon-time"></span>
+                        </a>
+                    {% endif %}
+
                 </div>
             {% endif %}
         </h1>
@@ -42,48 +43,57 @@
         {% endif %}
     {% endifequal %}
 
-    {% for sponsorshipperiod in sponsorshipperiods %}
-        <div class="row" style="margin-top:10px;">
 
-            <div class="col-lg-4">
-                <h5>{{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.sponsorshiplevel }} {{ sponsorshipperiod.start_date }}
-                    - {{ sponsorshipperiod.end_date }}
-                </h5>
 
-            </div>
-            <div class="col-lg-2">
-                {% if sponsorshipperiod.sponsor.logo %}
-                    <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
-                        <img class="img-responsive"
-                             src="{% thumbnail sponsorshipperiod.sponsor.logo 20x20 crop %}"/>
-                    </a>
-                {% endif %}
-            </div>
-
-            <div class="col-lg-6">
-                <div class="btn-group pull-right">
-                    {% if not sponsorshipperiod.approved and user.is_staff %}
-                        <a class="btn btn-default btn-mini"
-                           href='{% url "sponsorshipperiod-approve" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                            <span class="glyphicon glyphicon-thumbs-up"></span>
-                        </a>
-                        <a class="btn btn-default btn-mini"
-                           href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                            {% show_button_icon "delete" %}
-                        </a>
-                        <a class="btn btn-default btn-mini"
-                           href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                            {% show_button_icon "update" %}
+    <div class="container">
+        <table class="table">
+            <thead>
+            <tr>
+                <th>Logo</th>
+                <th>Organisation</th>
+                <th>Sponsorship Period</th>
+                <th>View</th>
+            </tr>
+            </thead>
+            {% for sponsorshipperiod in sponsorshipperiods %}
+                <tbody>
+                <tr>
+                    <td>
+                        {% if sponsorshipperiod.sponsor.logo %}
+                        <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
+                            <img class="img-responsive"
+                                 src="{% thumbnail sponsorshipperiod.sponsor.logo 20x20 crop %}"/>
                         </a>
                     {% endif %}
-                    <a class="btn btn-default btn-mini"
-                       href='{% url "sponsorshipperiod-detail" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
-                        <span class="glyphicon glyphicon-eye-open"></span>
-                    </a>
-                </div>
-            </div>
-        </div>
-    {% endfor %}
+                    </td>
+                    <td>{{ sponsorshipperiod.sponsor }}</td>
+                    <td>{{ sponsorshipperiod.start_date }} - {{ sponsorshipperiod.end_date }}</td>
+                    <td>
+
+                        {% if not sponsorshipperiod.approved and user.is_staff %}
+                            <a class="btn btn-default btn-mini"
+                               href='{% url "sponsorshipperiod-approve" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                                <span class="glyphicon glyphicon-thumbs-up"></span>
+                            </a>
+                            <a class="btn btn-default btn-mini"
+                               href='{% url "sponsorshipperiod-delete" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                                {% show_button_icon "delete" %}
+                            </a>
+                            <a class="btn btn-default btn-mini"
+                               href='{% url "sponsorshipperiod-update" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                                {% show_button_icon "update" %}
+                            </a>
+                        {% endif %}
+                        <a class="btn btn-default btn-mini"
+                           href='{% url "sponsorshipperiod-detail" project_slug=sponsorshipperiod.project.slug slug=sponsorshipperiod.slug %}'>
+                            <span class="glyphicon glyphicon-eye-open"></span>
+                        </a>
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
     <hr/>
     {% include "_pagination.html" %}
 {% endblock %}

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -21,13 +21,13 @@
                        href='{% url "sponsorshipperiod-create" project_slug %}'
                        data-title="Create New sponsorship period">
                         <span class="glyphicon glyphicon-asterisk"></span></a>
-                        {% if not unapproved %}
-                            <a class="btn btn-default btn-mini tooltip-toggle"
-                               href='{% url "pending-sponsorshipperiod-list" project_slug %}'
-                               data-title="View Pending sponsorship period">
-                                <span class="glyphicon glyphicon-time"></span>
-                            </a>
-                        {% endif %}
+                    {% if not unapproved %}
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                           href='{% url "pending-sponsorshipperiod-list" project_slug %}'
+                           data-title="View Pending sponsorship period">
+                            <span class="glyphicon glyphicon-time"></span>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
         </h1>
@@ -46,20 +46,21 @@
         <div class="row" style="margin-top:10px;">
 
             <div class="col-lg-4">
-                <h5>{{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.sponsorshiplevel }} {{ sponsorshipperiod.start_date }} - {{ sponsorshipperiod.end_date }}
+                <h5>{{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.sponsorshiplevel }} {{ sponsorshipperiod.start_date }}
+                    - {{ sponsorshipperiod.end_date }}
                 </h5>
 
             </div>
             <div class="col-lg-2">
-            {% if sponsorshipperiod.sponsor.logo %}
-                        <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
-                            <img class="img-responsive"
-                                 src="{% thumbnail sponsorshipperiod.sponsor.logo 20x20 crop %}"/>
-                        </a>
-                    {% endif %}
+                {% if sponsorshipperiod.sponsor.logo %}
+                    <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
+                        <img class="img-responsive"
+                             src="{% thumbnail sponsorshipperiod.sponsor.logo 20x20 crop %}"/>
+                    </a>
+                {% endif %}
             </div>
 
-            <div class="col-lg-5">
+            <div class="col-lg-6">
                 <div class="btn-group pull-right">
                     {% if not sponsorshipperiod.approved and user.is_staff %}
                         <a class="btn btn-default btn-mini"

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -14,7 +14,7 @@
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
-            Sponsorship Period
+            Sponsorship Periods
             {% if user.is_authenticated %}
                 <div class="pull-right btn-group">
                     <a class="btn btn-default btn-mini tooltip-toggle"
@@ -44,26 +44,22 @@
 
     {% for sponsorshipperiod in sponsorshipperiods %}
         <div class="row" style="margin-top:10px;">
-            <div class="col-lg-1">
-                {% if sponsorshipperiod.sponsor.logo %}
-                    <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
-                        <img class="img-responsive img-rounded pull-right"
-                             src="{% thumbnail sponsorshipperiod.sponsor.logo 50x50 crop %}"/>
-                    </a>
-                {% endif %}
-            {% if sponsorshipperiod.sponsorshiplevel.logo %}
-                <img class="img-responsive img-rounded"
-                     src="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsorshiplevel.logo }}" width="30" />
-              {%  endif %}
-            </div>
-            <div class="col-lg-9">
 
-                <h3>{{ sponsorshipperiod.start_date }} - {{ sponsorshipperiod.end_date }}</h3>
-                <h5>{{ sponsorshipperiod.sponsor }}</h5>
+            <div class="col-lg-4">
+                <h5>{{ sponsorshipperiod.sponsor }}, {{ sponsorshipperiod.sponsorshiplevel }} {{ sponsorshipperiod.start_date }} - {{ sponsorshipperiod.end_date }}
+                </h5>
 
-                <h5>{{ sponsorshipperiod.sponsorshiplevel }} : {{ sponsorshipperiod.project.name }}</h5>
             </div>
             <div class="col-lg-2">
+            {% if sponsorshipperiod.sponsor.logo %}
+                        <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
+                            <img class="img-responsive"
+                                 src="{% thumbnail sponsorshipperiod.sponsor.logo 20x20 crop %}"/>
+                        </a>
+                    {% endif %}
+            </div>
+
+            <div class="col-lg-5">
                 <div class="btn-group pull-right">
                     {% if not sponsorshipperiod.approved and user.is_staff %}
                         <a class="btn btn-default btn-mini"

--- a/django_project/changes/views/sponsorship_period.py
+++ b/django_project/changes/views/sponsorship_period.py
@@ -120,7 +120,7 @@ class SponsorshipPeriodListView(
     """List view for Sponsorship Period."""
     context_object_name = 'sponsorshipperiods'
     template_name = 'sponsorship_period/list.html'
-    paginate_by = 10
+    paginate_by = 1000
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.


### PR DESCRIPTION
Hi @timlinux this PR for #303 

This is the screenshot of new sponsorship periods. 
![screen shot 2016-06-30 at 4 51 42 pm](https://cloud.githubusercontent.com/assets/2235894/16484488/a55e443a-3ee3-11e6-96e8-267e1c080062.png)
 

- [x] Change the header to read <Project name> Sponsorship Periods
- [x] Put the record content all in a single line in the format:

[Organisation][start] - [end][view icon]

- [x] Put the most recent entry first
- [x] Make the pagination size very large e.g. 1000 lines
