### PR TITLE
Added release date information on the version and version list page

### DIFF
--- a/django_project/changes/templates/version/detail-content.html
+++ b/django_project/changes/templates/version/detail-content.html
@@ -24,7 +24,13 @@
                 <div class="col-lg-12">
                     <h3 class="muted align-right">
                         <small>Changelog for version:</small>
-                        {{ version.name }}</h3>
+                        {{ version.name }}
+                        </br>
+                        {% if version.release_date %}
+                        <small>Release date:</small> {{ version.release_date }}
+                        {% endif %}
+                    </h3>
+
                 </div>
             {% else %}
                 <div class="col-lg-12">

--- a/django_project/changes/templates/version/includes/version-list-detail.html
+++ b/django_project/changes/templates/version/includes/version-list-detail.html
@@ -14,8 +14,12 @@
         <h3>
             <a href="{% url 'version-detail' project_slug=version.project.slug slug=version.slug %}">
                 {{ version.name }}
+                {% if version.release_date %}
+                -- Release date: {{ version.release_date }}
+                {% endif %}
             </a>
         </h3>
+
     </div>
 
     <div class="col-lg-3">


### PR DESCRIPTION
Hi @timlinux this PR for #278 

The results: 

![screen shot 2016-07-04 at 4 01 15 am](https://cloud.githubusercontent.com/assets/2235894/16547552/4edecb28-419c-11e6-935f-51f6c97581d2.png)
![screen shot 2016-07-04 at 4 01 25 am](https://cloud.githubusercontent.com/assets/2235894/16547553/4f8f9052-419c-11e6-8cb0-557ad4a71feb.png)
