### PR TITLE
Pending items broken

### DIFF
--- a/django_project/changes/templates/sponsor/pending-list.html
+++ b/django_project/changes/templates/sponsor/pending-list.html
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsor-create" project_slug %}'
                        data-title="Create New Sponsor">
-                        {% show_button_icon "add" %}
+                        {% show_button_icon "add" %}</a>
 
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -20,7 +20,7 @@
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsorshiplevel-create" project_slug %}'
                        data-title="Create New Sponsorship Level">
-                        {% show_button_icon "add" %}
+                        {% show_button_icon "add" %}</a>
 
                         {% if not unapproved %}
                             <a class="btn btn-default btn-mini tooltip-toggle"

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -47,6 +47,7 @@
 
     <div class="container">
         <table class="table">
+        {% if sponsorshipperiods %}
             <thead>
             <tr>
                 <th>Logo</th>
@@ -55,6 +56,7 @@
                 <th>View</th>
             </tr>
             </thead>
+        {% endif %}
             {% for sponsorshipperiod in sponsorshipperiods %}
                 <tbody>
                 <tr>


### PR DESCRIPTION
Hi @timlinux 

There are two missing `</a>` so it makes page broken. 
![screen shot 2016-07-05 at 1 17 54 pm](https://cloud.githubusercontent.com/assets/2235894/16575670/4cb6c094-42b4-11e6-8d8f-520beb1c397d.png)

And also, the head of table now is hidden when sponsorship period is empty. 

Previously:
![screen shot 2016-07-05 at 1 20 44 pm](https://cloud.githubusercontent.com/assets/2235894/16575686/6370dcac-42b4-11e6-8ffc-dbaa1a3659e9.png)


Thanks. 