### PR TITLE
Add back button on entries page

### DIFF
--- a/django_project/base/templatetags/custom_markup.py
+++ b/django_project/base/templatetags/custom_markup.py
@@ -30,7 +30,8 @@ def show_button_icon(context, value):
     context_icon = {
         'add': 'glyphicon glyphicon-asterisk',
         'update': 'glyphicon glyphicon-pencil',
-        'delete': 'glyphicon glyphicon-minus'
+        'delete': 'glyphicon glyphicon-minus',
+        'back': 'glyphicon glyphicon-arrow-left'
     }
 
     return {

--- a/django_project/changes/templates/entry/pending-list.html
+++ b/django_project/changes/templates/entry/pending-list.html
@@ -15,6 +15,11 @@
 
 {% block content %}
     <div class="page-header">
+        <a class="btn btn-default btn-mini tooltip-toggle"
+           data-title="Back to version detail"
+           href='{% url "version-detail" project_slug=entries.0.version.project.slug slug=entries.0.version.slug %}'>
+            {% show_button_icon "back" %}
+        </a>
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}Entries
             <small class="pull-right">


### PR DESCRIPTION
To address this issue https://github.com/kartoza/projecta/issues/239 I added back button on entries page. What do you think?

![screenshot from 2016-07-14 10 08 13](https://cloud.githubusercontent.com/assets/1979569/16826952/0660c8a2-49ac-11e6-9640-2044495e3fc9.png)
