### PR TITLE
Export rst without break lines

### DIFF
--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -554,7 +554,7 @@ class VersionDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
         # convert the html to rst
         converted_doc = pypandoc.convert(
             document.rendered_content.encode(
-                'utf8', 'ignore'), 'rst', format='html')
+                'utf8', 'ignore'), 'rst', format='html', extra_args=['--no-wrap'])
         converted_doc = converted_doc.replace('/media/images/', 'images/')
 
         # prepare the ZIP file


### PR DESCRIPTION
Hi @rduivenvoorde 
Thanks for your comment https://github.com/kartoza/projecta/issues/340. It seems now is without break line. 
![screen shot 2016-07-15 at 1 56 55 pm](https://cloud.githubusercontent.com/assets/2235894/16866169/3ae04f9c-4a94-11e6-9662-4b8c5ecfabfe.png)

