### PR TITLE
bug fixing : pending project is shown in all project

### DIFF
--- a/django_project/base/templates/project/includes/project-panel.html
+++ b/django_project/base/templates/project/includes/project-panel.html
@@ -4,9 +4,15 @@
   <div class="panel panel-default">
     <div class="panel-heading">
       <h3 class="panel-title">
-        <a href="{% url 'project-detail' project.slug %}">
-          {{ project.name }}
-        </a>
+        {% if project.approved %}
+            <a href="{% url 'project-detail' project.slug %}">
+              {{ project.name }}
+            </a>
+        {% else %}
+            <a>
+              {{ project.name }}
+            </a>
+        {% endif %}
         {% if user.is_authenticated %}
           <div class="btn-group pull-right" style="margin-top: -3px;">
         {% if not project.approved and user.is_staff %}

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -8,9 +8,15 @@
             <ul class="dropdown-menu">
                 {% for project in the_projects %}
                     <li>
-                        <a href="{% url 'project-detail' project.slug %}">
-                            {{ project.name }}
-                        </a>
+                        {% if project.approved %}
+                            <a href="{% url 'project-detail' project.slug %}">
+                                {{ project.name }}
+                            </a>
+                        {% else %}
+                            <a href="{% url 'pending-project-list' %}">
+                                {{ project.name }} <b>(pending)</b>
+                            </a>
+                        {% endif %}
                     </li>
                 {% endfor %}
             </ul>
@@ -27,22 +33,22 @@
             <li><a href="{% url "project-detail" the_project.slug %}" style="padding: 0;">
                 <img class="img-rounded"
                      src="{% thumbnail the_project.image_file 50x50 crop %}"/>
-                </a>
+            </a>
             </li>
         {% endif %}
         <li>
-            <a href="{% url "project-detail" the_project.slug %}" class="nav navbar-nav" >
+            <a href="{% url "project-detail" the_project.slug %}" class="nav navbar-nav">
                 {{ the_project.name }}
             </a>
 
         </li>
     </ul>
-     <ul class="nav navbar-nav">
+    <ul class="nav navbar-nav">
         <li>
             {% if the_committee and the_project %}
 
                 <a href="{% url 'committee-list' the_project.slug %}" class="dropdown-toggle" data-toggle="dropdown">
-                    Teams  <b class="caret"></b>
+                    Teams <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
                     <li>
@@ -61,10 +67,10 @@
                     Teams
                 </a>
             {% endif %}
-    </li>
+        </li>
     </ul>
     {% if user.is_staff %}
-    <ul class="nav navbar-nav">
+        <ul class="nav navbar-nav">
         <li>
             <a href="{% url "version-create" the_project.slug %}" class="dropdown-toggle" data-toggle="dropdown">
                 Changelog <b class="caret"></b>
@@ -74,9 +80,9 @@
                 <li><a href="{% url 'category-list' the_project.slug %}">Categories</a></li>
                 <li><a href="{% url 'version-list' the_project.slug %}">Versions</a></li>
             </ul>
-    </li>
+        </li>
     {% endif %}
-    </ul>
+</ul>
     <ul class="nav navbar-nav">
         <li>
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -90,7 +96,7 @@
                 {% endif %}
                 <li><a href="{% url 'sponsor-world-map' the_project.slug %}">Sponsors Map</a></li>
             </ul>
-    </li>
+        </li>
     </ul>
 
 {% endif %}


### PR DESCRIPTION
@timlinux @cchristelis @dimasciput 
i found bug that pending project is shown in "all project" navbar

_on landing page, i made test1_
![screenshot from 2016-07-18 11 20 23](https://cloud.githubusercontent.com/assets/4530905/16906073/2370e92c-4cdb-11e6-8ed5-20bc12fc2ca2.png)

_when click, it show "page not found"_
![screenshot from 2016-07-18 11 20 26](https://cloud.githubusercontent.com/assets/4530905/16906072/236e35a6-4cdb-11e6-9ff6-85df306e8867.png)

_i changed it by giving "pending" indicator_
![screenshot from 2016-07-18 11 20 39](https://cloud.githubusercontent.com/assets/4530905/16906074/23794914-4cdb-11e6-8ed6-a2f112d66fe9.png)

_and redirect to pending project list_
![screenshot from 2016-07-18 11 20 44](https://cloud.githubusercontent.com/assets/4530905/16906075/237c19dc-4cdb-11e6-8ab0-ef7716136f9c.png)