### PR TITLE
fixing bug on pending version acceptance

### DIFF
--- a/django_project/base/templates/project/includes/project-panel.html
+++ b/django_project/base/templates/project/includes/project-panel.html
@@ -58,32 +58,42 @@
       {% endif %}
       <h4 class="text-muted">
         Latest Versions
-        <a href="{% url 'version-create' project_slug=project.slug %}"
-           class="btn btn-default pull-right btn-sm tooltip-toggle"
-           data-title="Create New Version">
-          {% show_button_icon "add" %}
-        </a>
+        {% if project.approved %}
+            <a href="{% url 'version-create' project_slug=project.slug %}"
+               class="btn btn-default pull-right btn-sm tooltip-toggle"
+               data-title="Create New Version">
+              {% show_button_icon "add" %}
+            </a>
+        {% endif %}
       </h4>
       <hr/>
       {% if project.versions %}
         {% for version in project.latest_versions %}
-          <p>
-            <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}">
-            <strong><span class="text-muted">Version:</span> {{ version.name }}</strong>
-            </a>
-            <span class="btn-group pull-right">
-              <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}"
-                  class="btn btn-default btn-xs tooltip-toggle"
-                  data-placement="top" data-title="Changelog List">
-                <span class="glyphicon glyphicon-list"></span>
-              </a>
-              <a href="{% url "version-thumbs" project_slug=version.project.slug slug=version.slug %}"
-                 class="btn btn-default btn-xs tooltip-toggle"
-                 data-placement="top" data-title="Changelog Thumbs">
-                <span class="glyphicon glyphicon-th"></span>
-              </a>
-            </span>
-          </p>
+            {% if version.approved or user.is_authenticated %}
+              <p>
+                  {% if version.approved %}
+                    <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}">
+                    <strong><span class="text-muted">Version:</span> {{ version.name }}</strong>
+                    </a>
+                  {% else %}
+                    <a href="{% url "pending-version-list" version.project.slug%}">
+                    <strong><span class="text-muted">Version:</span> {{ version.name }}</strong> <b  class="text-muted">(pending)</b>
+                    </a>
+                  {% endif %}
+                <span class="btn-group pull-right">
+                  <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}"
+                      class="btn btn-default btn-xs tooltip-toggle"
+                      data-placement="top" data-title="Changelog List">
+                    <span class="glyphicon glyphicon-list"></span>
+                  </a>
+                  <a href="{% url "version-thumbs" project_slug=version.project.slug slug=version.slug %}"
+                     class="btn btn-default btn-xs tooltip-toggle"
+                     data-placement="top" data-title="Changelog Thumbs">
+                    <span class="glyphicon glyphicon-th"></span>
+                  </a>
+                </span>
+              </p>
+            {% endif %}
         {% endfor %}
           {% if project.more_than_threshold %}
               <strong><span class="text-muted">Latest {{ project.threshold }} of {{ project.versions.count }} versionss</span></strong>

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -181,7 +181,10 @@ class ProjectUpdateView(LoginRequiredMixin, ProjectMixin, UpdateView):
             return qs.filter(owner=self.request.user)
 
     def get_success_url(self):
-        return reverse('project-detail', kwargs={'slug': self.object.slug})
+        if self.object.approved:
+            return reverse('project-detail', kwargs={'slug': self.object.slug})
+        else:
+            return reverse('pending-project-list')
 
     def form_valid(self, form):
         """Check that there is no referential integrity error when saving."""

--- a/django_project/changes/models/version.py
+++ b/django_project/changes/models/version.py
@@ -4,13 +4,14 @@ from django.core.urlresolvers import reverse
 from common.utilities import version_slugify
 import os
 import logging
-from core.settings.contrib import STOP_WORDS
-from django.conf.global_settings import MEDIA_ROOT
-from django.db import models
 from .entry import Entry
 from .sponsorship_period import SponsorshipPeriod
+from core.settings.contrib import STOP_WORDS
+from django.core.exceptions import ValidationError
+from django.conf.global_settings import MEDIA_ROOT
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
+from django.db import models
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +98,11 @@ class Version(models.Model):
         )
         app_label = 'changes'
         # ordering = ['-datetime_created']
+
+    def clean(self):
+        if not self.project.approved:
+            raise ValidationError(
+                "can't create version because project is not approved yet")
 
     def save(self, *args, **kwargs):
         if not self.pk:

--- a/django_project/changes/models/version.py
+++ b/django_project/changes/models/version.py
@@ -7,7 +7,6 @@ import logging
 from .entry import Entry
 from .sponsorship_period import SponsorshipPeriod
 from core.settings.contrib import STOP_WORDS
-from django.core.exceptions import ValidationError
 from django.conf.global_settings import MEDIA_ROOT
 from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
@@ -98,11 +97,6 @@ class Version(models.Model):
         )
         app_label = 'changes'
         # ordering = ['-datetime_created']
-
-    def clean(self):
-        if not self.project.approved:
-            raise ValidationError(
-                "can't create version because project is not approved yet")
 
     def save(self, *args, **kwargs):
         if not self.pk:

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -446,10 +446,10 @@ class VersionUpdateView(StaffuserRequiredMixin, VersionMixin, UpdateView):
 
 
 class PendingVersionListView(
-    StaffuserRequiredMixin,
-    VersionMixin,
-    PaginationMixin,
-    ListView):
+        StaffuserRequiredMixin,
+        VersionMixin,
+        PaginationMixin,
+        ListView):
     """List view for pending Version. Staff see all """
     context_object_name = 'versions'
     template_name = 'version/list.html'

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -141,6 +141,13 @@ class VersionDetailView(VersionMixin, DetailView):
                     'Requested project does not exist.')
             try:
                 obj = queryset.filter(project=project).get(slug=slug)
+                if not obj.approved:
+                    raise Http404(
+                        'Sorry! The project you are requesting a version for '
+                        'could not be found or you do not have permission to '
+                        'view the version. Also the version may not be '
+                        'approved yet. Try logging in as a staff member if '
+                        'you wish to view it.')
                 return obj
             except Version.DoesNotExist:
                 raise Http404(
@@ -439,10 +446,10 @@ class VersionUpdateView(StaffuserRequiredMixin, VersionMixin, UpdateView):
 
 
 class PendingVersionListView(
-        StaffuserRequiredMixin,
-        VersionMixin,
-        PaginationMixin,
-        ListView):
+    StaffuserRequiredMixin,
+    VersionMixin,
+    PaginationMixin,
+    ListView):
     """List view for pending Version. Staff see all """
     context_object_name = 'versions'
     template_name = 'version/list.html'
@@ -515,7 +522,8 @@ class ApproveVersionView(StaffuserRequiredMixin, VersionMixin, RedirectView):
         :returns: A url.
         :rtype: str
         """
-        project = Project.objects.get(slug=project_slug)
+        project = Project.objects.filter(slug=project_slug)
+        project = get_object_or_404(project, approved=True)
         version_qs = Version.unapproved_objects.filter(project=project)
         version = get_object_or_404(version_qs, slug=slug)
         version.approved = True


### PR DESCRIPTION
here is the changes for this PR:
- version cannot be created for pending project
- pending version just be shown for logged in user (for the future, just for project administrator and collaborator, related with : https://github.com/kartoza/projecta/issues/349)
- pending version in project panel will redirect too pending version list view
- when changing pending project, it will be redirect to pending project list instead detail that not found
- make cannot access pending version listview for pending project 

_authenticated_
![screenshot from 2016-07-18 16 21 59](https://cloud.githubusercontent.com/assets/4530905/16911441/ac6005b0-4d08-11e6-8d83-3762a2dd3401.png)

__not authenticated_
![screenshot from 2016-07-18 16 22 09](https://cloud.githubusercontent.com/assets/4530905/16911442/ac651992-4d08-11e6-8275-ddf4543b7989.png)

this fix #357 