### PR TITLE
Fix redirect loop on rst download

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -2,7 +2,7 @@ psycopg2
 Django>=1.8,<1.9
 django-countries==3.4.1
 django-crispy-forms==1.4.0
-django-braces==1.8.1
+django-braces==1.9.0
 django-model-utils==1.4.0
 django-pipeline==1.3.11
 django-pure-pagination

--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -21,18 +21,20 @@
     <div class="row" style="margin-top:15px;margin-bottom:15px;">
         <div class="col-lg-12">
             <div class="btn-group btn-group pull-left">
-            <a class="btn btn-default btn-mini tooltip-toggle"
-                   data-title="Download sponsor list as html"
-                   href='{% url 'version-sponsor-download' project_slug=version.project.slug slug=version.slug %}'>
-                    <span class="glyphicon glyphicon-download"></span>
-                    <span style="font-size: 7pt;">H T M L</span>
-                </a>
-                <a class="btn btn-default btn-mini tooltip-toggle"
-                   data-title="Download as RST"
-                   href='{% url 'version-download' project_slug=version.project.slug slug=version.slug %}'>
-                    <span class="glyphicon glyphicon-download"></span>
-                    <span style="font-size: 7pt;">R S T</span>
-                </a>
+                {% if user.is_authenticated and user.is_staff %}
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       data-title="Download sponsor list as html"
+                       href='{% url 'version-sponsor-download' project_slug=version.project.slug slug=version.slug %}'>
+                        <span class="glyphicon glyphicon-download"></span>
+                        <span style="font-size: 7pt;">H T M L</span>
+                    </a>
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       data-title="Download as RST"
+                       href='{% url 'version-download' project_slug=version.project.slug slug=version.slug %}'>
+                        <span class="glyphicon glyphicon-download"></span>
+                        <span style="font-size: 7pt;">R S T</span>
+                    </a>
+                {% endif %}
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Download as GNU Changelog" data-toggle="tooltip"
                    href='{% url 'version-download-gnu' project_slug=version.project.slug slug=version.slug %}'>

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -43,6 +43,19 @@ class VersionMixin(object):
     form_class = VersionForm
 
 
+class CustomStaffuserRequiredMixin(StaffuserRequiredMixin):
+    """Fix redirect loop when user is already authenticated but non staff"""
+
+    def no_permissions_fail(self, request=None):
+        """
+        Called when the user has no permissions and no exception was raised.
+        """
+        if not request.user.is_authenticated():
+            return super(CustomStaffuserRequiredMixin, self).no_permissions_fail(request)
+
+        raise Http404('Sorry! You have to be staff to open this page.')
+
+
 class VersionListView(VersionMixin, PaginationMixin, ListView):
     """List view for Version."""
     context_object_name = 'versions'
@@ -562,7 +575,7 @@ class ApproveVersionView(StaffuserRequiredMixin, VersionMixin, RedirectView):
         })
 
 
-class VersionDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
+class VersionDownload(VersionMixin, CustomStaffuserRequiredMixin, DetailView):
     """View to allow staff users to download Version page in RST format"""
     template_name = 'version/detail-content.html'
 
@@ -733,7 +746,7 @@ class VersionDownloadGnu(VersionMixin, DetailView):
             content_type="text/plain; charset=utf-8")
 
 
-class VersionSponsorDownload(VersionMixin, StaffuserRequiredMixin, DetailView):
+class VersionSponsorDownload(VersionMixin, CustomStaffuserRequiredMixin, DetailView):
     """View to allow staff users to download Version page in html format"""
     template_name = 'version/includes/version-sponsors.html'
 


### PR DESCRIPTION
Fix #370
- Remove rst and sponsor download button for unauthenticated and non staff users

![screenshot from 2016-07-22 15 17 30](https://cloud.githubusercontent.com/assets/1979569/17050972/190a5368-5020-11e6-8919-b87a034fbdeb.png)
- Raise 404 when non staff user try to open download url page manually

![screenshot from 2016-07-22 15 18 29](https://cloud.githubusercontent.com/assets/1979569/17050994/33dc8634-5020-11e6-9061-889c30190c6b.png)
