### PR TITLE
limit image width

### DIFF
--- a/django_project/core/base_static/css/changelog.css
+++ b/django_project/core/base_static/css/changelog.css
@@ -129,6 +129,10 @@ ul.ui-sortable-disabled .order{
     cursor: pointer;
 }
 
+#container img{
+    max-width: 100%;
+}
+
 @media (min-width: 1200px) {
     #imagemodal .modal-dialog {
         width:1000px ;


### PR DESCRIPTION
Solving issue #386 

I edited changelog.css file.
The code should limit the image width so it will become like this:

![screenshot from 2017-03-08 15-46-59](https://cloud.githubusercontent.com/assets/26101337/23696501/851f1bf6-0416-11e7-89af-9be2b241e2a3.png)
