### PR TITLE
add create page for course type

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -88,7 +88,8 @@ class CourseTypeForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
         self.certifying_organisation = kwargs.pop('certifying_organisation')
-        form_title = 'New Course for %s' % self.certifying_organisation.name
+        form_title = \
+            'New Course Type for %s' % self.certifying_organisation.name
         self.helper = FormHelper()
         layout = Layout(
             Fieldset(

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -12,6 +12,7 @@ from crispy_forms.layout import (
 )
 from models import (
     CertifyingOrganisation,
+    CourseType
 )
 
 
@@ -69,4 +70,43 @@ class CertifyingOrganisationForm(forms.ModelForm):
         instance.approved = False
         instance.save()
         self.save_m2m()
+        return instance
+
+
+class CourseTypeForm(forms.ModelForm):
+
+    # noinspection PyClassicStyleClass
+    class Meta:
+        model = CourseType
+        fields = (
+            'name',
+            'description',
+            'instruction_hours',
+            'coursetype_link',
+        )
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user')
+        self.certifying_organisation = kwargs.pop('certifying_organisation')
+        form_title = 'New Course for %s' % self.certifying_organisation.name
+        self.helper = FormHelper()
+        layout = Layout(
+            Fieldset(
+                form_title,
+                Field('name', css_class='form-control'),
+                Field('description', css_class='form-control'),
+                Field('instruction_hours', css_class='form-control'),
+                Field('coursetype_link', css_class='form-control'),
+                css_id='project-form')
+        )
+        self.helper.layout = layout
+        self.helper.html5_required = False
+        super(CourseTypeForm, self).__init__(*args, **kwargs)
+        self.helper.add_input(Submit('submit', 'Submit'))
+
+    def save(self, commit=True):
+        instance = super(CourseTypeForm, self).save(commit=False)
+        instance.certifying_organisation = self.certifying_organisation
+        instance.author = self.user
+        instance.save()
         return instance

--- a/django_project/certification/models/course_type.py
+++ b/django_project/certification/models/course_type.py
@@ -34,6 +34,7 @@ class CourseType(SlugifyingMixin, models.Model):
     )
 
     coursetype_link = models.CharField(
+        verbose_name='Link',
         help_text='Link to course types',
         max_length=200,
         null=True,

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -187,7 +187,7 @@
         <div class="col-lg-2">
             <div class="btn-group">
                 <a class="btn btn-default btn-xs tooltip-toggle"
-                   href='#'
+                   href='{% url "coursetype-delete" project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug slug=coursetype.slug %}'
                    data-title="Delete {{ coursetype.name }}">
                     <span class="glyphicon glyphicon-minus"></span>
                 </a>

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -192,7 +192,7 @@
                     <span class="glyphicon glyphicon-minus"></span>
                 </a>
                 <a class="btn btn-default btn-xs tooltip-toggle"
-                   href='#'
+                   href='{% url "coursetype-update" project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug slug=coursetype.slug %}'
                    data-title="Edit {{ coursetype.name }}">
                     <span class="glyphicon glyphicon-pencil"></span>
                 </a>

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -179,7 +179,8 @@
     {% for coursetype in coursetypes %}
         <div class="col-lg-10">
             <li style="margin-left: 20px; margin-top: 10px;" id="{{ coursetype.id }}-{{ coursetype.name }}">
-                {{ coursetype.name }}
+                <a href="{% url 'coursetype-detail' project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug slug=coursetype.slug %}">
+                    {{ coursetype.name }}</a>
             </li>
         </div>
 

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -159,7 +159,7 @@
         <div class="col-lg-2">
             <div class="btn-group">
             <a class="btn btn-default btn-sm tooltip-toggle"
-               href='#'
+               href='{% url 'coursetype-create' project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug %}'
                data-title="Create New Course Type">
                 {% show_button_icon "add" %}
             </a>
@@ -172,7 +172,7 @@
     {% ifequal num_coursetype 0 %}
         <h5>No course types are defined, but you can <a
                     class="btn btn-default btn-mini"
-                    href='#'>create one</a>.</h5>
+                    href='{% url 'coursetype-create' project_slug=certifyingorganisation.project.slug organisation_slug=certifyingorganisation.slug %}'>create one</a>.</h5>
     {% endifequal %}
 
     <div class="row">

--- a/django_project/certification/templates/course_type/create.html
+++ b/django_project/certification/templates/course_type/create.html
@@ -3,7 +3,7 @@
 {% load crispy_forms_tags %}
 
 {% block page_title %}
-    <h1>Add Certifying Organisation</h1>
+    <h1>Add Course Type</h1>
 {% endblock page_title %}
 
 {% block content %}

--- a/django_project/certification/templates/course_type/create.html
+++ b/django_project/certification/templates/course_type/create.html
@@ -1,0 +1,21 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Add Certifying Organisation</h1>
+{% endblock page_title %}
+
+{% block content %}
+
+    <section id="forms">
+        <div class='container'>
+            {% csrf_token %}
+            {% crispy form %}
+            {% for form in inlines %}
+                {% crispy form %}
+            {% endfor %}
+        </div>
+    </section>
+
+{% endblock %}

--- a/django_project/certification/templates/course_type/delete.html
+++ b/django_project/certification/templates/course_type/delete.html
@@ -1,0 +1,49 @@
+{% extends "project_base.html" %}
+{% load custom_markup %}
+
+{% block title %}Course Type Deleted - {{ block.super }}{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+    <h1>Course Type Deleted</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <form action="" id="delete-confirmation" method="post">{% csrf_token %}
+        <div class="alert row">
+            <div class="col-lg-10">
+                <p class="lead">Are you sure you want to delete the course type below?</p>
+            </div>
+            <div class="col-lg-2">
+                <div class="btn-group">
+                    <a class="btn btn-default btn-sm tooltip-toggle"
+                       href="#"
+                       onClick="$('#delete-confirmation').submit()"
+                       data-title="Delete {{ coursetype.name }}">
+                        <span class="glyphicon glyphicon-minus"></span>
+                    </a>
+                    <a class="btn btn-default btn-sm tooltip-toggle"
+                       href='{% url "certifyingorganisation-detail" coursetype.certifying_organisation.project.slug coursetype.certifying_organisation.slug %}'
+                       data-title="Cancel">
+                        <span class="glyphicon glyphicon-arrow-left"></span>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">
+                <h3>Course Type: {{ coursetype.name }}</h3>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-8">
+                Name : {{ coursetype.name }}<br/>
+                Description : {{ coursetype.description }}<br/>
+                Instruction Hours : {{ coursetype.instruction_hours }}<br/>
+                Link : {{ coursetype.coursetype_link }}<br/>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/django_project/certification/templates/course_type/detail.html
+++ b/django_project/certification/templates/course_type/detail.html
@@ -1,0 +1,56 @@
+{% extends "project_base.html" %}
+{% load custom_markup %}
+
+{% block title %}Course Type - {{ block.super }}{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+    <h1>Available Course Types</h1>
+{% endblock page_title %}
+
+{% block content %}
+
+    <div class="row">
+        <div class=".col-md-4">
+            <div class="col-lg-10">
+            <h1>{{ coursetype.name }}</h1>
+        </div>
+
+        {# Only organisation owners or staff can edit #}
+        <div class="col-lg-2">
+            <div class="btn-group">
+                {% if user in certifyingorganisation.organisation_owners.all or user.is_staff %}
+                <a class="btn btn-default btn-sm tooltip-toggle"
+                   href='{% url "coursetype-delete" project_slug=coursetype.certifying_organisation.project.slug organisation_slug=coursetype.certifying_organisation.slug slug=coursetype.slug %}'
+                   data-title="Delete {{ coursetype.name }}">
+                    <span class="glyphicon glyphicon-minus"></span>
+                </a>
+                <a class="btn btn-default btn-sm tooltip-toggle"
+                   href='{% url "coursetype-update" project_slug=coursetype.certifying_organisation.project.slug organisation_slug=coursetype.certifying_organisation.slug slug=coursetype.slug %}'
+                   data-title="Edit {{ coursetype.name }}">
+                    <span class="glyphicon glyphicon-pencil"></span>
+                </a>
+                {% endif %}
+                 <a class="btn btn-default btn-sm tooltip-toggle"
+                    href='{% url "certifyingorganisation-detail" coursetype.certifying_organisation.project.slug coursetype.certifying_organisation.slug %}'
+                    data-title="Back">
+                     <span class="glyphicon glyphicon-arrow-left"></span>
+                 </a>
+            </div>
+        </div>
+        </div>
+    </div>
+
+    </div>
+    <div class="row">
+    <div class="col-lg-8">
+        Name : {{ coursetype.name }}<br/>
+        Description : {{ coursetype.description }}<br/>
+        Instruction Hours : {{ coursetype.instruction_hours }}<br/>
+        Link : {{ coursetype.coursetype_link }}<br/>
+    </div>
+    </div>
+
+{% endblock %}

--- a/django_project/certification/templates/course_type/update.html
+++ b/django_project/certification/templates/course_type/update.html
@@ -1,0 +1,21 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Update Course Type</h1>
+{% endblock page_title %}
+
+{% block content %}
+
+    <section id="forms">
+        <div class='container'>
+            {% csrf_token %}
+            {% crispy form %}
+            {% for form in inlines %}
+                {% crispy form %}
+            {% endfor %}
+        </div>
+    </section>
+
+{% endblock %}

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -13,6 +13,7 @@ from views import (
     ApproveCertifyingOrganisationView,
 
     CourseTypeCreateView,
+    CourseTypeUpdateView,
 )
 
 
@@ -52,4 +53,8 @@ urlpatterns = patterns(
               '(?P<organisation_slug>[\w-]+)/create-coursetype/$',
         view=CourseTypeCreateView.as_view(),
         name='coursetype-create'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/(?P<slug>[\w-]+)/update/$',
+        view=CourseTypeUpdateView.as_view(),
+        name='coursetype-update'),
 )

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -15,6 +15,7 @@ from views import (
     CourseTypeCreateView,
     CourseTypeDeleteView,
     CourseTypeUpdateView,
+    CourseTypeDetailView,
 )
 
 
@@ -62,4 +63,8 @@ urlpatterns = patterns(
               '(?P<organisation_slug>[\w-]+)/(?P<slug>[\w-]+)/delete/$',
         view=CourseTypeDeleteView.as_view(),
         name='coursetype-delete'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/(?P<slug>[\w-]+)/$',
+        view=CourseTypeDetailView.as_view(),
+        name='coursetype-detail'),
 )

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -13,6 +13,7 @@ from views import (
     ApproveCertifyingOrganisationView,
 
     CourseTypeCreateView,
+    CourseTypeDeleteView,
     CourseTypeUpdateView,
 )
 
@@ -57,4 +58,8 @@ urlpatterns = patterns(
               '(?P<organisation_slug>[\w-]+)/(?P<slug>[\w-]+)/update/$',
         view=CourseTypeUpdateView.as_view(),
         name='coursetype-update'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/(?P<slug>[\w-]+)/delete/$',
+        view=CourseTypeDeleteView.as_view(),
+        name='coursetype-delete'),
 )

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -11,6 +11,8 @@ from views import (
     CertifyingOrganisationUpdateView,
     PendingCertifyingOrganisationListView,
     ApproveCertifyingOrganisationView,
+
+    CourseTypeCreateView,
 )
 
 
@@ -44,4 +46,10 @@ urlpatterns = patterns(
               '(?P<slug>[\w-]+)/update/$',
         view=CertifyingOrganisationUpdateView.as_view(),
         name='certifyingorganisation-update'),
+
+    # Course Type
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/create-coursetype/$',
+        view=CourseTypeCreateView.as_view(),
+        name='coursetype-create'),
 )

--- a/django_project/certification/views/__init__.py
+++ b/django_project/certification/views/__init__.py
@@ -1,2 +1,3 @@
 
 from certifying_organisation import *
+from course_type import *

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -16,7 +16,7 @@ from ..forms import CourseTypeForm
 
 
 class CourseTypeMixin(object):
-    """Mixin class to provide standard settings for Certifying Organisation."""
+    """Mixin class to provide standard settings for Course Type."""
 
     model = CourseType
     form_class = CourseTypeForm
@@ -34,8 +34,7 @@ class CourseTypeCreateView(
         """Define the redirect URL
 
         After successful creation of the object, the User will be redirected
-        to the unapproved Certifying Organisation list page
-        for the object's parent Project
+        to the unapproved Certifying Organisation detail page
 
        :returns: URL
        :rtype: HttpResponse
@@ -168,7 +167,7 @@ class CourseTypeDeleteView(
 class CourseTypeUpdateView(LoginRequiredMixin,
                            CourseTypeMixin,
                            UpdateView):
-    """Update view for Certifying Organisation."""
+    """Update view for Course Type."""
 
     context_object_name = 'coursetype'
     template_name = 'course_type/update.html'
@@ -248,7 +247,7 @@ class CourseTypeUpdateView(LoginRequiredMixin,
 
 class CourseTypeDetailView(
         CourseTypeMixin, DetailView):
-    """Detail view for Certifying Organisation."""
+    """Detail view for Course Type."""
 
     context_object_name = 'coursetype'
     template_name = 'course_type/detail.html'

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -31,10 +31,10 @@ class CourseTypeCreateView(
     template_name = 'course_type/create.html'
 
     def get_success_url(self):
-        """Define the redirect URL
+        """Define the redirect URL.
 
         After successful creation of the object, the User will be redirected
-        to the unapproved Certifying Organisation detail page
+        to the Certifying Organisation detail page.
 
        :returns: URL
        :rtype: HttpResponse
@@ -55,8 +55,8 @@ class CourseTypeCreateView(
         :rtype: dict
         """
 
-        context = super(CourseTypeCreateView,
-                        self).get_context_data(**kwargs)
+        context = super(
+            CourseTypeCreateView, self).get_context_data(**kwargs)
         context['coursetypes'] = self.get_queryset() \
             .filter(certifying_organisation=self.certifying_organisation)
         return context
@@ -68,8 +68,7 @@ class CourseTypeCreateView(
         :rtype: dict
         """
 
-        kwargs = super(CourseTypeCreateView,
-                       self).get_form_kwargs()
+        kwargs = super(CourseTypeCreateView, self).get_form_kwargs()
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
@@ -91,7 +90,7 @@ class CourseTypeDeleteView(
 
     def get(self, request, *args, **kwargs):
         """
-        Get the organisation_slug from the URL and define the Organisation
+        Get the organisation_slug from the URL and define the Organisation.
 
         :param request: HTTP request object
         :type request: HttpRequest
@@ -109,11 +108,11 @@ class CourseTypeDeleteView(
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
-        return super(CourseTypeDeleteView,
-                     self).get(request, *args, **kwargs)
+        return super(
+            CourseTypeDeleteView, self).get(request, *args, **kwargs)
 
     def post(self, request, *args, **kwargs):
-        """Post the project_slug from the URL and define the Project
+        """Post the project_slug from the URL and define the Project.
 
         :param request: HTTP request object
         :type request: HttpRequest
@@ -131,14 +130,13 @@ class CourseTypeDeleteView(
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
-        return super(CourseTypeDeleteView,
-                     self).post(request, *args, **kwargs)
+        return super(CourseTypeDeleteView, self).post(request, *args, **kwargs)
 
     def get_success_url(self):
-        """Define the redirect URL
+        """Define the redirect URL.
 
         After successful deletion  of the object, the User will be redirected
-        to the Certifying Organisation detail page
+        to the Certifying Organisation detail page.
 
         :returns: URL
         :rtype: HttpResponse
@@ -164,9 +162,10 @@ class CourseTypeDeleteView(
         return qs
 
 
-class CourseTypeUpdateView(LoginRequiredMixin,
-                           CourseTypeMixin,
-                           UpdateView):
+class CourseTypeUpdateView(
+        LoginRequiredMixin,
+        CourseTypeMixin,
+        UpdateView):
     """Update view for Course Type."""
 
     context_object_name = 'coursetype'
@@ -179,8 +178,8 @@ class CourseTypeUpdateView(LoginRequiredMixin,
         :rtype: dict
         """
 
-        kwargs = super(CourseTypeUpdateView,
-                       self).get_form_kwargs()
+        kwargs = super(
+            CourseTypeUpdateView, self).get_form_kwargs()
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
@@ -200,8 +199,8 @@ class CourseTypeUpdateView(LoginRequiredMixin,
         :rtype: dict
         """
 
-        context = super(CourseTypeUpdateView,
-                        self).get_context_data(**kwargs)
+        context = super(
+            CourseTypeUpdateView, self).get_context_data(**kwargs)
         context['coursetypes'] = self.get_queryset() \
             .filter(certifying_organisation=self.certifying_organisation)
         return context
@@ -220,7 +219,7 @@ class CourseTypeUpdateView(LoginRequiredMixin,
             return qs.filter(creator=self.request.user)
 
     def get_success_url(self):
-        """Define the redirect URL
+        """Define the redirect URL.
 
         After successful update of the object, the User will be redirected to
         the Certifying Organisation detail page
@@ -238,11 +237,11 @@ class CourseTypeUpdateView(LoginRequiredMixin,
         """Check that there is no referential integrity error when saving."""
 
         try:
-            return super(CourseTypeUpdateView,
-                         self).form_valid(form)
+            return super(
+                CourseTypeUpdateView, self).form_valid(form)
         except IntegrityError:
             return ValidationError(
-                'ERROR: Course Type is already exists!')
+                'ERROR: Course Type already exists!')
 
 
 class CourseTypeDetailView(
@@ -265,8 +264,8 @@ class CourseTypeDetailView(
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
         self.certifying_organisation = \
             CertifyingOrganisation.objects.get(slug=self.organisation_slug)
-        context = super(CourseTypeDetailView,
-                        self).get_context_data(**kwargs)
+        context = super(
+            CourseTypeDetailView, self).get_context_data(**kwargs)
         context['coursetypes'] = CourseType.objects.filter(
             certifying_organisation=self.certifying_organisation)
         return context
@@ -289,7 +288,7 @@ class CourseTypeDetailView(
         :type queryset: QuerySet
 
         :returns: Queryset which is filtered to only show a course type
-            within the organisation
+            within the organisation.
         :rtype: QuerySet
         :raises: Http404
         """
@@ -305,5 +304,4 @@ class CourseTypeDetailView(
                     certifying_organisation=certifying_organisation, slug=slug)
                 return obj
             else:
-                raise Http404('Sorry! We could not find '
-                              'your course types!')
+                raise Http404('Sorry! We could not find your course type!')

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -1,21 +1,12 @@
 # coding=utf-8
 from django.core.urlresolvers import reverse
-from django.shortcuts import get_object_or_404
-from django.http import HttpResponse
 from django.views.generic import (
     CreateView)
-from django.http import HttpResponseRedirect, Http404
-from django.db import IntegrityError
-from django.core.exceptions import ValidationError
-from braces.views import LoginRequiredMixin, StaffuserRequiredMixin
-from pure_pagination.mixins import PaginationMixin
-from base.models import Project
+from braces.views import LoginRequiredMixin
 from ..models import (
     CertifyingOrganisation,
-    TrainingCenter,
     CourseType,
-    CourseConvener,
-    Course)
+    )
 from ..forms import CourseTypeForm
 
 
@@ -76,7 +67,8 @@ class CourseTypeCreateView(
         kwargs = super(CourseTypeCreateView,
                        self).get_form_kwargs()
         self.organisation_slug = self.kwargs.get('organisation_slug', None)
-        self.certifying_organisation = CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        self.certifying_organisation = \
+            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
         kwargs.update({
             'user': self.request.user,
             'certifying_organisation': self.certifying_organisation,

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -5,8 +5,7 @@ from django.views.generic import (
 from braces.views import LoginRequiredMixin
 from ..models import (
     CertifyingOrganisation,
-    CourseType,
-    )
+    CourseType)
 from ..forms import CourseTypeForm
 
 

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from django.core.urlresolvers import reverse
+from django.http import Http404
 from django.views.generic import (
     CreateView,
+    DeleteView,
     UpdateView)
 from django.db import IntegrityError
 from django.core.exceptions import ValidationError
@@ -76,6 +78,90 @@ class CourseTypeCreateView(
             'certifying_organisation': self.certifying_organisation,
         })
         return kwargs
+
+
+class CourseTypeDeleteView(
+        LoginRequiredMixin,
+        CourseTypeMixin,
+        DeleteView):
+    """Delete view for Course Type."""
+
+    context_object_name = 'coursetype'
+    template_name = 'course_type/delete.html'
+
+    def get(self, request, *args, **kwargs):
+        """
+        Get the organisation_slug from the URL and define the Organisation
+
+        :param request: HTTP request object
+        :type request: HttpRequest
+
+        :param args: Positional arguments
+        :type args: tuple
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+
+        :returns: Unaltered request object
+        :rtype: HttpResponse
+        """
+
+        self.organisation_slug = self.kwargs.get('organisation_slug', None)
+        self.certifying_organisation = \
+            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        return super(CourseTypeDeleteView,
+                     self).get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        """Post the project_slug from the URL and define the Project
+
+        :param request: HTTP request object
+        :type request: HttpRequest
+
+        :param args: Positional arguments
+        :type args: tuple
+
+        :param kwargs: Keyword arguments
+        :type kwargs: dict
+
+        :returns: Unaltered request object
+        :rtype: HttpResponse
+        """
+
+        self.organisation_slug = self.kwargs.get('organisation_slug', None)
+        self.certifying_organisation = \
+            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        return super(CourseTypeDeleteView,
+                     self).post(request, *args, **kwargs)
+
+    def get_success_url(self):
+        """Define the redirect URL
+
+        After successful deletion  of the object, the User will be redirected
+        to the Certifying Organisation detail page
+
+        :returns: URL
+        :rtype: HttpResponse
+        """
+
+        return reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.object.certifying_organisation.project.slug,
+            'slug': self.object.certifying_organisation.slug
+        })
+
+    def get_queryset(self):
+        """Get the queryset for this view.
+
+        :returns: Course Type queryset filtered by Certifying Organisation
+        :rtype: QuerySet
+        :raises: Http404
+        """
+
+        if not self.request.user.is_authenticated():
+            raise Http404
+        qs = CourseType.objects.filter(
+            certifying_organisation=self.certifying_organisation)
+        return qs
 
 
 class CourseTypeUpdateView(LoginRequiredMixin,

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+from django.core.urlresolvers import reverse
+from django.shortcuts import get_object_or_404
+from django.http import HttpResponse
+from django.views.generic import (
+    CreateView)
+from django.http import HttpResponseRedirect, Http404
+from django.db import IntegrityError
+from django.core.exceptions import ValidationError
+from braces.views import LoginRequiredMixin, StaffuserRequiredMixin
+from pure_pagination.mixins import PaginationMixin
+from base.models import Project
+from ..models import (
+    CertifyingOrganisation,
+    TrainingCenter,
+    CourseType,
+    CourseConvener,
+    Course)
+from ..forms import CourseTypeForm
+
+
+class CourseTypeMixin(object):
+    """Mixin class to provide standard settings for Certifying Organisation."""
+
+    model = CourseType
+    form_class = CourseTypeForm
+
+
+class CourseTypeCreateView(
+        LoginRequiredMixin,
+        CourseTypeMixin, CreateView):
+    """Create view for Course Type."""
+
+    context_object_name = 'coursetype'
+    template_name = 'course_type/create.html'
+
+    def get_success_url(self):
+        """Define the redirect URL
+
+        After successful creation of the object, the User will be redirected
+        to the unapproved Certifying Organisation list page
+        for the object's parent Project
+
+       :returns: URL
+       :rtype: HttpResponse
+       """
+
+        return reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.object.certifying_organisation.project.slug,
+            'slug': self.object.certifying_organisation.slug
+        })
+
+    def get_context_data(self, **kwargs):
+        """Get the context data which is passed to a template.
+
+        :param kwargs: Any arguments to pass to the superclass.
+        :type kwargs: dict
+
+        :returns: Context data which will be passed to the template.
+        :rtype: dict
+        """
+
+        context = super(CourseTypeCreateView,
+                        self).get_context_data(**kwargs)
+        context['coursetypes'] = self.get_queryset() \
+            .filter(certifying_organisation=self.certifying_organisation)
+        return context
+
+    def get_form_kwargs(self):
+        """Get keyword arguments from form.
+
+        :returns keyword argument from the form
+        :rtype: dict
+        """
+
+        kwargs = super(CourseTypeCreateView,
+                       self).get_form_kwargs()
+        self.organisation_slug = self.kwargs.get('organisation_slug', None)
+        self.certifying_organisation = CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        kwargs.update({
+            'user': self.request.user,
+            'certifying_organisation': self.certifying_organisation,
+        })
+        return kwargs

--- a/django_project/certification/views/course_type.py
+++ b/django_project/certification/views/course_type.py
@@ -1,7 +1,10 @@
 # coding=utf-8
 from django.core.urlresolvers import reverse
 from django.views.generic import (
-    CreateView)
+    CreateView,
+    UpdateView)
+from django.db import IntegrityError
+from django.core.exceptions import ValidationError
 from braces.views import LoginRequiredMixin
 from ..models import (
     CertifyingOrganisation,
@@ -73,3 +76,84 @@ class CourseTypeCreateView(
             'certifying_organisation': self.certifying_organisation,
         })
         return kwargs
+
+
+class CourseTypeUpdateView(LoginRequiredMixin,
+                           CourseTypeMixin,
+                           UpdateView):
+    """Update view for Certifying Organisation."""
+
+    context_object_name = 'certifyingorganisation'
+    template_name = 'certifying_organisation/update.html'
+
+    def get_form_kwargs(self):
+        """Get keyword arguments from form.
+
+        :returns keyword argument from the form
+        :rtype: dict
+        """
+
+        kwargs = super(CourseTypeUpdateView,
+                       self).get_form_kwargs()
+        self.organisation_slug = self.kwargs.get('organisation_slug', None)
+        self.certifying_organisation = \
+            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        kwargs.update({
+            'user': self.request.user,
+            'certifying_organisation': self.certifying_organisation
+        })
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        """Get the context data which is passed to a template.
+
+        :param kwargs: Any arguments to pass to the superclass.
+        :type kwargs: dict
+
+        :returns: Context data which will be passed to the template.
+        :rtype: dict
+        """
+
+        context = super(CourseTypeUpdateView,
+                        self).get_context_data(**kwargs)
+        context['coursetypes'] = self.get_queryset() \
+            .filter(certifying_organisation=self.certifying_organisation)
+        return context
+
+    def get_queryset(self):
+        """Get the queryset for this view.
+
+        :returns: query set that is all Course Type objects
+        :rtype: QuerySet
+        """
+
+        qs = CourseType.objects.all()
+        if self.request.user.is_staff:
+            return qs
+        else:
+            return qs.filter(creator=self.request.user)
+
+    def get_success_url(self):
+        """Define the redirect URL
+
+        After successful update of the object, the User will be redirected to
+        the Certifying Organisation detail page
+
+        :returns: URL
+        :rtype: HttpResponse
+        """
+
+        return reverse('certifyingorganisation-detail', kwargs={
+            'project_slug': self.object.certifying_organisation.project.slug,
+            'slug': self.object.certifying_organisation.slug
+        })
+
+    def form_valid(self, form):
+        """Check that there is no referential integrity error when saving."""
+
+        try:
+            return super(CourseTypeUpdateView,
+                         self).form_valid(form)
+        except IntegrityError:
+            return ValidationError(
+                'ERROR: Course Type is already exists!')


### PR DESCRIPTION
fix #410 

# Create Page
when user click on `create one` or `*` button
![screenshot from 2017-05-10 16-45-38](https://cloud.githubusercontent.com/assets/26101337/25893077/adc5221a-35a0-11e7-97b3-02b00ff490b7.png)

it will go to create course type page:
![screenshot from 2017-05-10 16-46-12](https://cloud.githubusercontent.com/assets/26101337/25893115/cc3f31b8-35a0-11e7-820e-6a1dfc51c10d.png)
![screenshot from 2017-05-10 16-46-24](https://cloud.githubusercontent.com/assets/26101337/25893124/cfddff48-35a0-11e7-986d-f505043ea887.png)

when it is done, it will come back to organisation details page:
![screenshot from 2017-05-10 16-51-57](https://cloud.githubusercontent.com/assets/26101337/25893184/14b1a0f2-35a1-11e7-8614-c2ad1e535eea.png)
![screenshot from 2017-05-10 16-52-09](https://cloud.githubusercontent.com/assets/26101337/25893185/152a88e6-35a1-11e7-8e97-8e6b9ed79c7d.png)
![screenshot from 2017-05-10 16-52-21](https://cloud.githubusercontent.com/assets/26101337/25893188/1661d00c-35a1-11e7-9dd1-b312a28060c9.png)


# Update Page
when user click on :pencil2: button next to course type name, it will direct them to update page
![screenshot from 2017-05-11 13-13-05](https://cloud.githubusercontent.com/assets/26101337/25935185/043c1b66-364c-11e7-9909-01fb87d13576.png)
update page layout is the same as create page layout.
when update is done, user is directed to organisation details page.


# Delete Page
when user click on :heavy_minus_sign: button next to course type name, it will direct them to delete page
![screenshot from 2017-05-11 13-55-39](https://cloud.githubusercontent.com/assets/26101337/25936379/a4af64fe-3651-11e7-97f8-bccc1240bef4.png)

delete page
![screenshot from 2017-05-11 13-55-09](https://cloud.githubusercontent.com/assets/26101337/25936387/ab65c2c0-3651-11e7-909b-96533550cfdd.png)

click on :heavy_minus_sign: will delete the course type while click on :arrow_left: button will cancel and direct the user to organisation detail page


# Detail view
when user click on the name of course type link, it will direct them to detail page
![screenshot from 2017-05-11 14-46-26](https://cloud.githubusercontent.com/assets/26101337/25938239/cae9f524-3658-11e7-9925-3e72c916efcc.png)

from detail page, they can click on buttons to edit or delete or to go back to previous page
![screenshot from 2017-05-11 14-46-43](https://cloud.githubusercontent.com/assets/26101337/25938283/e4396b9a-3658-11e7-9e19-a73ddb7a69f9.png)
