### PR TITLE
add admin

### DIFF
--- a/django_project/core/settings/prod_docker.py
+++ b/django_project/core/settings/prod_docker.py
@@ -12,7 +12,8 @@ ALLOWED_HOSTS = ['*']
 ADMINS = (
     ('Tim Sutton', 'tim@kartoza.com'),
     ('Ismail Sunni', 'ismail@kartoza.com'),
-    ('Christian Christellis', 'christian@kartoza.com'),)
+    ('Christian Christellis', 'christian@kartoza.com'),
+    ('Anita Hapsari', 'anita@kartoza.com'),)
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Currently, I am not aware if the http error still persist ( #394 ).
So I think it would be good to add my email address in the admin, thus if the error happens again, I will be notified too.