### PR TITLE
fix url at certificate

### DIFF
--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -153,6 +153,7 @@ def certificate_pdf_view(request, **kwargs):
     course = Course.objects.get(slug=course_slug)
     attendee = Attendee.objects.get(pk=pk)
     certificate = Certificate.objects.get(course=course, attendee=attendee)
+    current_site = request.META['HTTP_HOST']
 
     # Create the HttpResponse object with the appropriate PDF headers.
     response = HttpResponse(content_type='application/pdf')
@@ -278,8 +279,9 @@ def certificate_pdf_view(request, **kwargs):
     page.setFont('Times-Roman', 8)
     page.drawString(
         margin_left, (margin_bottom - 20),
-        'You can verify this certificate by visiting /%s/certificate/%s/.'
-        % (project.slug, certificate.certificateID))
+        'You can verify this certificate by visiting '
+        'http://%s/en/%s/certificate/%s/.'
+        % (current_site, project.slug, certificate.certificateID))
 
     # Close the PDF object cleanly.
     page.showPage()


### PR DESCRIPTION
fix #472 

the certificate now:
![screenshot from 2017-07-25 14-11-09](https://user-images.githubusercontent.com/26101337/28560098-7d7a2f0e-7143-11e7-9d09-d0e63804221e.png)

the url (depends on domain name):
![screenshot from 2017-07-25 14-14-12](https://user-images.githubusercontent.com/26101337/28560111-8faa7bb6-7143-11e7-8769-1d4dda7e8d3a.png)
