### PR TITLE
add server name in nginx conf

### DIFF
--- a/deployment/sites-enabled/default.conf
+++ b/deployment/sites-enabled/default.conf
@@ -18,7 +18,7 @@ server {
     # the port your site will be served on
     listen      8080;
     # the domain name it will serve for
-    #server_name *;
+    server_name staging.projecta.kartoza.com changelog.linfiniti.com changelog.kartoza.com changelog.qgis.org changelog.inasafe.org staging.changelog.qgis.org;
     charset     utf-8;
 
     # max upload size, adjust to taste

--- a/django_project/core/settings/dev_docker.py
+++ b/django_project/core/settings/dev_docker.py
@@ -4,6 +4,9 @@ from .dev import *  # noqa
 import os
 print os.environ
 
+ALLOWED_HOSTS = ['*',
+                 u'0.0.0.0']
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.contrib.gis.db.backends.postgis',


### PR DESCRIPTION
fix #394 

This PR configures nginx, so that it only accepts connections for specific hosts (server_name).
Also add allowed host for dev