### PR TITLE
add course date validation

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -276,8 +276,8 @@ class CourseForm(forms.ModelForm):
                 Field('course_convener',
                       css_class='form-control chosen-select'),
                 Field('training_center', css_class='form-control'),
-                Field('start_date', css_class='form-control datepicker-here'),
-                Field('end_date', css_class='form-control datepicker-here'),
+                Field('start_date', css_class='form-control'),
+                Field('end_date', css_class='form-control'),
                 Field('template_certificate', css_class='form-control'),
             )
         )

--- a/django_project/certification/templates/course/create.html
+++ b/django_project/certification/templates/course/create.html
@@ -21,9 +21,27 @@
 
     <script>
     $(function() {
-        $( ".datepicker-here" ).datepicker({
-            language: "en",
-            position: "top left"
+        $("#id_start_date").attr('data-language', 'en');
+        $("#id_end_date").attr('data-language', 'en');
+
+        $("#id_start_date").datepicker({
+            dateFormat: 'yyyy-mm-dd',
+            autoClose: true,
+            position: 'top left',
+            onSelect: function (date) {
+                $("#id_end_date").val(date);
+                $("#id_end_date").datepicker({minDate: new Date(date)})
+            }
+        });
+
+        $("#id_end_date").datepicker({
+            dateFormat: 'yyyy-mm-dd',
+            autoClose: true,
+            position: 'top left',
+            onSelect: function (date) {
+                $("#id_start_date").val(date);
+                $("#id_start_date").datepicker({maxDate: new Date(date)})
+            }
         });
     });
     </script>

--- a/django_project/certification/templates/course/update.html
+++ b/django_project/certification/templates/course/update.html
@@ -11,6 +11,10 @@
 {% block js_head %}
     <script src="{% static 'js/datepicker.js' %}"></script>
     <script src="{% static 'js/i18n/datepicker.en.js' %}"></script>
+    <script>
+
+
+    </script>
 {% endblock %}
 
 {% block page_title %}
@@ -18,6 +22,47 @@
 {% endblock page_title %}
 
 {% block content %}
+
+    <script>
+        $(function() {
+            var start_date = $("#id_start_date").val();
+            var end_date = $("#id_end_date").val();
+
+            $("#id_start_date").attr('data-language', 'en');
+            $("#id_end_date").attr('data-language', 'en');
+
+            $("#id_start_date").datepicker({
+                dateFormat: 'yyyy-mm-dd',
+                autoClose: true,
+                position: 'top left',
+                onSelect: function (date) {
+                    $("#id_end_date").val(date);
+                    $("#id_end_date").datepicker({minDate: new Date(date)})
+                }
+            });
+
+            $("#id_end_date").datepicker({
+                dateFormat: 'yyyy-mm-dd',
+                autoClose: true,
+                position: 'top left',
+                onSelect: function (date) {
+                    $("#id_start_date").val(date);
+                    $("#id_start_date").datepicker({maxDate: new Date(date)})
+                }
+            });
+
+            $("#id_start_date").datepicker({
+                maxDate: new Date(end_date.toString())
+            });
+            $('#id_start_date').datepicker().data('datepicker').selectDate(new Date(start_date.toString()));
+
+            $("#id_end_date").datepicker({
+                minDate: new Date(start_date.toString())
+            });
+            $('#id_end_date').datepicker().data('datepicker').selectDate(new Date(end_date.toString()));
+
+        });
+    </script>
 
     <section id="forms">
         <div class='container'>


### PR DESCRIPTION
This PR add validation for input course start date and end date
- [x] When course start date is available, the input course end date can only be after course start date
- [x] When course end date is available, the input course start date can only be before course end date
- [x] Datepicker automatically close when a date is selected

![peek 2017-07-31 10-31](https://user-images.githubusercontent.com/26101337/28762025-64cf8398-75dd-11e7-9562-c97974dd7a8d.gif)
