### PR TITLE
use real name for organisation owners

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -73,6 +73,8 @@ class CertifyingOrganisationForm(forms.ModelForm):
         self.helper.layout = layout
         self.helper.html5_required = False
         super(CertifyingOrganisationForm, self).__init__(*args, **kwargs)
+        self.fields['organisation_owners'].label_from_instance = \
+            lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):


### PR DESCRIPTION
In the organisation add/edit page:

for organisation owners:
![screenshot from 2017-08-02 16-20-06](https://user-images.githubusercontent.com/26101337/28866983-d8493eaa-779e-11e7-907e-ec3f7348dded.png)
