### PR TITLE
add user automatically as default organisation owner

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -75,6 +75,7 @@ class CertifyingOrganisationForm(forms.ModelForm):
         super(CertifyingOrganisationForm, self).__init__(*args, **kwargs)
         self.fields['organisation_owners'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
+        self.fields['organisation_owners'].initial = [self.user]
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):


### PR DESCRIPTION
When a user create an organisation, he will be automatically chosen as an organisation owner.

![screenshot from 2017-08-08 16-12-37](https://user-images.githubusercontent.com/26101337/29064995-edc3b4a8-7c54-11e7-879e-8bb971c5b9c0.png)
