### PR TITLE
download certificates as a zip

### DIFF
--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -83,7 +83,7 @@
            href='{% url 'courseattendee-create' project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
             data-title="Add Course Attendees">
             {% show_button_icon "add" %}</a>
-        <a class="btn btn-info btn-sm tooltip-toggle pull-right" style=" margin-top: -30px"
+        <a id='download-zip' class="btn btn-default btn-sm tooltip-toggle pull-right" style=" margin-top: -30px"
            href='{% url "download_zip_all" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug %}'
             data-title="Download all issued certificates from this course">
             <span class="glyphicon glyphicon-download-alt"></span>
@@ -144,5 +144,16 @@
 
     </div>
     </div>
+
+    <script>
+        $('#download-zip').hover(
+            function (){
+                $(this).removeClass('btn-default').addClass('btn-info')
+            },
+            function () {
+                $(this).removeClass('btn-info').addClass('btn-default')
+            }
+        )
+    </script>
 
 {% endblock %}

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -78,10 +78,17 @@
     <tr style="border: none"><td style="border: none; padding: 0"><h3 style="margin-top: -20px">Course attendees</h3></td>
     {% if user in course.certifying_organisation.organisation_owners.all or user.is_staff or user == course.course_convener.user %}
     <td style="border: none; padding: 0;">
-        <a class="btn btn-default btn-sm tooltip-toggle pull-right" style=" margin-top: -30px"
+    <div class="btn-group pull-right">
+        <a class="btn btn-default btn-sm tooltip-toggle" style=" margin-top: -30px"
            href='{% url 'courseattendee-create' project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
             data-title="Add Course Attendees">
             {% show_button_icon "add" %}</a>
+        <a class="btn btn-info btn-sm tooltip-toggle pull-right" style=" margin-top: -30px"
+           href='{% url "download_zip_all" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug %}'
+            data-title="Download all issued certificates from this course">
+            <span class="glyphicon glyphicon-download-alt"></span>
+            </a>
+    </div>
     </td></tr>
     {% endif %}
     </table>

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -46,6 +46,7 @@ from views import (
     CertificateCreateView,
     CertificateDetailView,
     certificate_pdf_view,
+    download_certificates_zip,
 
     # Validate Certificate.
     ValidateCertificate,
@@ -198,6 +199,10 @@ urlpatterns = patterns(
         '(?P<organisation_slug>[\w-]+)/course/'
         '(?P<course_slug>[\w-]+)/print/(?P<pk>[\w-]+)/$',
         certificate_pdf_view, name='print-certificate'),
+    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+        '(?P<organisation_slug>[\w-]+)/course/'
+        '(?P<course_slug>[\w-]+)/download_zip/$',
+        download_certificates_zip, name='download_zip_all'),
 
     # Search.
     url(regex='^(?P<project_slug>[\w-]+)/certificate/$',


### PR DESCRIPTION
Download all issued certificates in one course as one zip file

In course details page:
![screenshot from 2017-08-10 11-55-39](https://user-images.githubusercontent.com/26101337/29155010-1942e1e8-7dc3-11e7-8fe8-7541e193ae5a.png)

When the download button is clicked, user can save/view the zip file:
![screenshot from 2017-08-10 12-00-15](https://user-images.githubusercontent.com/26101337/29155088-b387884e-7dc3-11e7-9478-17729f692b23.png)

The zip file contains folder with course name and all issued certificates is inside that folder:
![screenshot from 2017-08-10 12-03-40](https://user-images.githubusercontent.com/26101337/29155122-fa3e06a0-7dc3-11e7-8db3-0a15ce282763.png)

