### PR TITLE
add project name in listing admin page

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -51,6 +51,7 @@ class CertifyingOrganisationForm(forms.ModelForm):
             'organisation_phone',
             'logo',
             'organisation_owners',
+            'project',
         )
 
     def __init__(self, *args, **kwargs):
@@ -76,11 +77,12 @@ class CertifyingOrganisationForm(forms.ModelForm):
         self.fields['organisation_owners'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         self.fields['organisation_owners'].initial = [self.user]
+        self.fields['project'].initial = self.project
+        self.fields['project'].widget = forms.HiddenInput()
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):
         instance = super(CertifyingOrganisationForm, self).save(commit=False)
-        instance.project = self.project
         instance.save()
         self.save_m2m()
         return instance

--- a/django_project/certification/migrations/0010_auto_20170817_1718.py
+++ b/django_project/certification/migrations/0010_auto_20170817_1718.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0009_auto_20170710_0708'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='certifyingorganisation',
+            name='name',
+            field=models.CharField(help_text='name of organisation or institution', max_length=200),
+        ),
+        migrations.AlterUniqueTogether(
+            name='certifyingorganisation',
+            unique_together=set([('name', 'project')]),
+        ),
+    ]

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -81,8 +81,7 @@ class CertifyingOrganisation(SlugifyingMixin, models.Model):
         help_text=_('name of organisation or institution'),
         max_length=200,
         null=False,
-        blank=False,
-        unique=True
+        blank=False
     )
 
     organisation_email = models.CharField(
@@ -143,12 +142,13 @@ class CertifyingOrganisation(SlugifyingMixin, models.Model):
 
         app_label = 'certification'
         ordering = ['name']
+        unique_together = ['name', 'project']
 
     def save(self, *args, **kwargs):
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 
     def __unicode__(self):
-        return self.name
+        return '%s - %s' % (self.project.name, self.name)
 
     def get_absolute_url(self):
         """Return URL to certifying organisation detail page.


### PR DESCRIPTION
fix #496

this PR includes:
- [x] add project name in list in the admin page
- [x] add project's name and organisation's name as unique together

in admin:
![screenshot from 2017-08-17 22-25-37](https://user-images.githubusercontent.com/26101337/29420297-c700c8a8-839b-11e7-96ba-07662396b132.png)
