### PR TITLE
fix organisation slug and improve course name display

### DIFF
--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -74,7 +74,7 @@ def validate_email_address(value):
         return False
 
 
-class CertifyingOrganisation(SlugifyingMixin, models.Model):
+class CertifyingOrganisation(models.Model):
     """Certifying organisation model."""
 
     name = models.CharField(
@@ -145,6 +145,13 @@ class CertifyingOrganisation(SlugifyingMixin, models.Model):
         unique_together = ['name', 'project']
 
     def save(self, *args, **kwargs):
+        if not self.pk:
+            words = self.name.split()
+            filtered_words = [word for word in words if
+                              word.lower() not in STOP_WORDS]
+            # unidecode() represents special characters (unicode data) in ASCII
+            new_list = unidecode(' '.join(filtered_words))
+            self.slug = self.project.name.lower() + '-' + slugify(new_list)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -151,7 +151,8 @@ class CertifyingOrganisation(models.Model):
                               word.lower() not in STOP_WORDS]
             # unidecode() represents special characters (unicode data) in ASCII
             new_list = unidecode(' '.join(filtered_words))
-            self.slug = self.project.name.lower() + '-' + slugify(new_list)[:50]
+            self.slug = \
+                self.project.name.lower() + '-' + slugify(new_list)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -151,7 +151,7 @@ class CertifyingOrganisation(models.Model):
                               word.lower() not in STOP_WORDS]
             # unidecode() represents special characters (unicode data) in ASCII
             new_list = \
-                self.project.name.lower() + ' ' + \
+                self.project.slug + ' ' + \
                 unidecode(' '.join(filtered_words))
             self.slug = slugify(new_list)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -150,9 +150,10 @@ class CertifyingOrganisation(models.Model):
             filtered_words = [word for word in words if
                               word.lower() not in STOP_WORDS]
             # unidecode() represents special characters (unicode data) in ASCII
-            new_list = unidecode(' '.join(filtered_words))
-            self.slug = \
-                self.project.name.lower() + '-' + slugify(new_list)[:50]
+            new_list = \
+                self.project.name.lower() + ' ' + \
+                unidecode(' '.join(filtered_words))
+            self.slug = slugify(new_list)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -394,7 +394,7 @@
     {% for course in courses %}
         <tr style="list-style-type: none; margin-left: 20px; margin-top: 10px;">
         <td id="{{ course.id }}-{{ course.name }}">
-                {{ course.name }}
+                {{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})
         </td>
         <td id="{{ course.id }}-{{ course.training_center.name }}">
                 {{ course.training_center.name }}

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -15,7 +15,7 @@
 
     <div class="row">
         <div class="col-lg-10">
-        <h1>{{ course.name }}</h1><br/>
+        <h1>{{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})</h1><br/>
         </div>
 
         <div class="col-lg-2" style="margin-top: 20px">

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -42,7 +42,7 @@
     </div>
 
     <div class="details" style="margin-top: 15px; width: 60%">
-        <span class="grey-italic col-lg-3">Course name</span><span class="col-lg-9">{{ course.name }}<br/></span>
+        <span class="grey-italic col-lg-3">Course name</span><span class="col-lg-9">{{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})<br/></span>
         <span class="grey-italic col-lg-3">Course type</span><span class="col-lg-9">{{ course.course_type }}<br/></span>
         <span class="grey-italic col-lg-3">Course convener</span>
         {% if course.course_convener.user.first_name %}


### PR DESCRIPTION
fix #483 

This PR:
- [x] fixes organisation slug, add the project name so there will not be duplicates
organisation slug is using project slug, thus: project slug-organisation name e.g. qgis-kartoza
- [x] fixes course name display

![screenshot from 2017-08-21 10-05-14](https://user-images.githubusercontent.com/26101337/29502260-e2391c50-8658-11e7-9039-104a7124c77e.png)
![screenshot from 2017-08-21 10-09-03](https://user-images.githubusercontent.com/26101337/29502261-e2f524ae-8658-11e7-9e59-84478df21463.png)
