### PR TITLE
fix certificate url

### DIFF
--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -98,12 +98,10 @@ class CertificateCreateView(
 
         try:
             super(CertificateCreateView, self).form_valid(form)
-            certificate_id = form.instance.certificateID
+            pk = self.attendee.pk
+            site = self.request.get_host()
 
             # Send email to the attendee when the certificate is issued.
-            if Site._meta.installed:
-                site = Site.objects.get_current().domain
-
             send_mail(
                 'Certificate from %s Course' % self.course.course_type,
                 'Dear %s %s,\n\n' % (
@@ -117,13 +115,16 @@ class CertificateCreateView(
                     self.course.end_date.strftime('%d %B %Y')) +
                 'Training center: %s\n' % self.course.training_center +
                 'Certifying organisation: %s\n\n'
-                % self.course.certifying_organisation +
-                'You may check the full details of the certificate '
+                % self.course.certifying_organisation.name +
+                'You may print the certificate '
                 'by visiting:\n'
-                'http://%s/en/%s/certificate/%s/\n\n' % (
+                'http://%s/en/%s/certifyingorganisation/%s/course/'
+                '%s/print/%s/\n\n' % (
                     site,
                     self.course.certifying_organisation.project.slug,
-                    certificate_id
+                    self.course.certifying_organisation.slug,
+                    self.course.slug,
+                    pk
                 ) +
                 'Sincerely,\n%s %s' % (
                     self.course.course_convener.user.first_name,

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -4,7 +4,6 @@ import os
 import zipfile
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.views.generic import CreateView, DetailView
-from django.contrib.sites.models import Site
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError


### PR DESCRIPTION
fix #510

in console, the email is as follows:
```
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 7bit
Subject: Certificate from Coding for Dummies Course
From: anita@kartoza.com
To: janeausten@gmail.com
Date: Mon, 21 Aug 2017 09:28:12 -0000
Message-ID: <20170821092812.5206.24232@uwsgi>

Dear Jane Austen,

Congratulations!
Your certificate from the following course has been issued.

Course type: Coding for Dummies
Course date: 11 July 2017 to 19 December 2017
Training center: training center B
Certifying organisation: OrganisationX

You may print the certificate by visiting:
http://0.0.0.0:61202/en/x-project/certifyingorganisation/xproject-organisationx/course/xproject_coding-for-dummies_2017-07-11-2017-12-19/print/37/

Sincerely,
Anita Hapsari
```

The domain name depends upon the domain name where the certificate is issued.
In that example: 

```
attendee: Jane Austen (janeausten@gmail.com)
course convener: Anita Hapsari (anita@kartoza.com)