### PR TITLE
add notification for pending organisation

### DIFF
--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -18,7 +18,11 @@
     {% if message %}
       <div class="message-info">
           <p style="text-align: center; font-family: inherit; color: inherit; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
-             >{{ message }}</p>
+             >{{ message }}
+              {% for pending_organisation in pending_organisations %}
+                  <a href="{{ pending_organisation.project.slug }}/pending-certifyingorganisation/list/">here</a>
+              {% endfor %}
+          </p>
       </div>
     {% endif %}
     <div class="page-header">

--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -17,7 +17,7 @@
 {% block content %}
     {% if message %}
       <div class="message-info">
-          <p style="text-align: center; font-family: inherit; color: gray; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
+          <p style="text-align: center; font-family: inherit; color: inherit; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
              >{{ message }}</p>
       </div>
     {% endif %}

--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -15,6 +15,12 @@
 {% endblock %}
 
 {% block content %}
+    {% if message %}
+      <div class="message-info">
+          <p style="text-align: center; font-family: inherit; color: gray; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
+             >{{ message }}</p>
+      </div>
+    {% endif %}
     <div class="page-header">
       <p class="lead text-center text-muted">
         {% trans "High level software project management. Made easy." %}
@@ -51,4 +57,10 @@
     {% for project in projects %}
       {% include 'project/includes/project-panel.html' %}
     {%  endfor %}
+
+    <script>
+        $(document).click(function () {
+            $('.message-info').fadeOut('fast')
+        });
+    </script>
 {% endblock %}

--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -19,8 +19,8 @@
       <div class="message-info">
           <p style="text-align: center; font-family: inherit; color: inherit; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
              >{{ message }}
-              {% for pending_organisation in pending_organisations %}
-                  <a href="{{ pending_organisation.project.slug }}/pending-certifyingorganisation/list/">here</a>
+              {% for project in project_with_pending %}
+                  <a href="{{ project.slug }}/pending-certifyingorganisation/list/">here</a>
               {% endfor %}
           </p>
       </div>

--- a/django_project/base/templates/project/list.html
+++ b/django_project/base/templates/project/list.html
@@ -15,15 +15,44 @@
 {% endblock %}
 
 {% block content %}
+    <style>
+        .pending-notification {
+            text-align: center;
+            font-family: inherit;
+            color: inherit;
+            background: #e0ecff;
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #e0ecff
+        }
+        .cursor-pointer {
+            cursor: pointer;
+        }
+    </style>
+
     {% if message %}
-      <div class="message-info">
-          <p style="text-align: center; font-family: inherit; color: inherit; background: #e0ecff; padding: 10px; border-radius: 5px; border: 1px solid #e0ecff"
-             >{{ message }}
-              {% for project in project_with_pending %}
-                  <a href="{{ project.slug }}/pending-certifyingorganisation/list/">here</a>
-              {% endfor %}
-          </p>
-      </div>
+        {% if num_project_with_pending == 1 %}
+          <div class="message-info">
+              <p class="pending-notification"
+                 >{{ message }}
+                      Follow <a href="{{ project_with_pending.0.slug }}/pending-certifyingorganisation/list/">this link</a> to review.
+              </p>
+          </div>
+        {% elif num_project_with_pending > 1 %}
+            <div class="message-info-multiple">
+                <p class="pending-notification"
+                 >{{ message }}
+                  Follow <a class="cursor-pointer" onclick="displayLink()" >this link</a> to review.
+                </p>
+                <p style="text-align: center">
+                {% for project in project_with_pending %}
+                    <span class="pending-notification pending-project-link" style="display: none">
+                        <a href="{{ project.slug }}/pending-certifyingorganisation/list/">{{ project.name }}</a>
+                    </span>&nbsp;
+                {% endfor %}
+                </p>
+          </div>
+        {% endif %}
     {% endif %}
     <div class="page-header">
       <p class="lead text-center text-muted">
@@ -66,5 +95,17 @@
         $(document).click(function () {
             $('.message-info').fadeOut('fast')
         });
+
+        $(document).click(function (event) {
+            if (!$(event.target).is(".cursor-pointer")) {
+                $('.message-info-multiple').fadeOut('fast');
+            }
+        });
+
+        function displayLink() {
+            $('.pending-project-link').each(function () {
+                $(this).show()
+            })
+        }
     </script>
 {% endblock %}

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -90,8 +90,10 @@ class ProjectListView(ProjectMixin, PaginationMixin, ListView):
                 project=project, approved=False
             )
             if pending_organisation:
+                context['pending_organisations'] = pending_organisation
                 context['message'] = \
-                    'You have a pending organisation approval.'
+                    'You have a pending organisation approval. ' \
+                    'Follow this link to review: '
         return context
 
     def get_queryset(self):

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -21,6 +21,7 @@ from changes.models import Version
 from ..models import Project
 from ..forms import ProjectForm
 from vota.models import Committee, Ballot
+from certification.models import CertifyingOrganisation
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,12 @@ class ProjectListView(ProjectMixin, PaginationMixin, ListView):
         context['num_projects'] = self.get_queryset().count()
         context[
             'PROJECT_VERSION_LIST_SIZE'] = settings.PROJECT_VERSION_LIST_SIZE
+        project = Project.objects.filter(owner=self.request.user)
+        pending_organisation = CertifyingOrganisation.objects.filter(
+            project=project, approved=False
+        )
+        if self.request.user.is_authenticated() and pending_organisation:
+            context['message'] = 'You have pending organisation approval.'
         return context
 
     def get_queryset(self):

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -84,12 +84,14 @@ class ProjectListView(ProjectMixin, PaginationMixin, ListView):
         context['num_projects'] = self.get_queryset().count()
         context[
             'PROJECT_VERSION_LIST_SIZE'] = settings.PROJECT_VERSION_LIST_SIZE
-        project = Project.objects.filter(owner=self.request.user)
-        pending_organisation = CertifyingOrganisation.objects.filter(
-            project=project, approved=False
-        )
-        if self.request.user.is_authenticated() and pending_organisation:
-            context['message'] = 'You have pending organisation approval.'
+        if self.request.user.is_authenticated():
+            project = Project.objects.filter(owner=self.request.user)
+            pending_organisation = CertifyingOrganisation.objects.filter(
+                project=project, approved=False
+            )
+            if pending_organisation:
+                context['message'] = \
+                    'You have a pending organisation approval.'
         return context
 
     def get_queryset(self):

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -90,7 +90,12 @@ class ProjectListView(ProjectMixin, PaginationMixin, ListView):
                 project=project, approved=False
             )
             if pending_organisation:
-                context['pending_organisations'] = pending_organisation
+                context['project_with_pending'] = []
+                for organisation in pending_organisation:
+                    if organisation.project not in \
+                            context['project_with_pending']:
+                        context['project_with_pending'].append(
+                            organisation.project)
                 context['message'] = \
                     'You have a pending organisation approval. ' \
                     'Follow this link to review: '

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -89,16 +89,18 @@ class ProjectListView(ProjectMixin, PaginationMixin, ListView):
             pending_organisation = CertifyingOrganisation.objects.filter(
                 project=project, approved=False
             )
+            context['num_project_with_pending'] = 0
             if pending_organisation:
                 context['project_with_pending'] = []
+
                 for organisation in pending_organisation:
                     if organisation.project not in \
                             context['project_with_pending']:
                         context['project_with_pending'].append(
                             organisation.project)
+                        context['num_project_with_pending'] += 1
                 context['message'] = \
-                    'You have a pending organisation approval. ' \
-                    'Follow this link to review: '
+                    'You have a pending organisation approval. '
         return context
 
     def get_queryset(self):

--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -11,6 +11,28 @@
 {% endblock page_title %}
 
 {% block content %}
+    <style>
+        .success {
+            text-align: center;
+            font-family: inherit;
+            color: inherit;
+            background: #adffd2;
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #96ffc5;
+        }
+    </style>
+
+    {% if messages %}
+    <div class="messages">
+        {% for message in messages %}
+            {% if 'organisation_submitted' in message.tags %}
+                <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
@@ -106,6 +128,9 @@
     {% include "_pagination.html" %}
 
     <script>
+        $(document).click(function () {
+            $('.messages').fadeOut('fast')
+        });
         $('.btn-delete').hover(
             function (){
                 $(this).removeClass('btn-default').addClass('btn-danger')
@@ -113,7 +138,7 @@
             function (){
                 $(this).removeClass('btn-danger').addClass('btn-default')
             }
-        )
+        );
         $('.btn-approved').hover(
             function (){
                 $(this).removeClass('btn-default').addClass('btn-success')

--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -72,7 +72,7 @@
             }
         </script>
         <div class="row" style="margin-top:10px;">
-            <div class="col-lg-9">
+            <div class="col-lg-10">
                 <h5>{{ certifyingorganisation.project.name }}</h5>
 
                 <h3>{{ certifyingorganisation.name }}</h3>

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from base.models import Project
+from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponse
@@ -341,8 +342,31 @@ class CertifyingOrganisationDeleteView(
         return qs
 
 
+class CustomSuccessMessageMixin(object):
+    """
+    Adds a success message and extra tags on successful form submission.
+    """
+    success_message = ''
+    message_extra_tags = ''
+
+    def form_valid(self, form):
+        response = super(CustomSuccessMessageMixin, self).form_valid(form)
+        success_message = self.get_success_message(form.cleaned_data)
+        message_extra_tags = self.get_extra_tags(form.cleaned_data)
+        if success_message:
+            messages.success(self.request, success_message, message_extra_tags)
+        return response
+
+    def get_success_message(self, cleaned_data):
+        return self.success_message % cleaned_data
+
+    def get_extra_tags(self, cleaned_data):
+        return self.message_extra_tags % cleaned_data
+
+
 # noinspection PyAttributeOutsideInit
 class CertifyingOrganisationCreateView(
+        CustomSuccessMessageMixin,
         LoginRequiredMixin,
         CertifyingOrganisationMixin,
         CreateView):
@@ -350,6 +374,9 @@ class CertifyingOrganisationCreateView(
 
     context_object_name = 'certifyingorganisation'
     template_name = 'certifying_organisation/create.html'
+    success_message = 'Your organisation is successfully registered. '\
+                      'It is now waiting for an approval.'
+    message_extra_tags = 'organisation_submitted'
 
     def get_success_url(self):
         """Define the redirect URL.

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from base.models import Project
 from django.contrib import messages
+from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponse
@@ -422,6 +423,27 @@ class CertifyingOrganisationCreateView(
 
         try:
             super(CertifyingOrganisationCreateView, self).form_valid(form)
+            site = self.request.get_host()
+
+            send_mail(
+                'Projecta - New Pending Organisation Approval',
+                'Dear %s %s,\n\n' % (
+                    self.project.owner.first_name,
+                    self.project.owner.last_name) +
+                'You have a new organisation registered to your project: %s.\n'
+                % self.project.name +
+                'You may review and approve the organisation by following this'
+                ' link:\n'
+                '%s/en/%s/pending-certifyingorganisation/list/\n\n'
+                % (site, self.project_slug) +
+                'Sincerely,\n\n\n\n\n'
+                '----------------------------------------------------------\n'
+                'This is an auto-generated email from the system.'
+                ' Please do not reply to this email.',
+                self.project.owner.email,
+                [self.project.owner.email],
+                fail_silently=False,
+            )
             return HttpResponseRedirect(self.get_success_url())
         except IntegrityError:
             return ValidationError(

--- a/django_project/core/settings/base.py
+++ b/django_project/core/settings/base.py
@@ -106,6 +106,7 @@ TEMPLATES = [
 
                 # `allauth` needs this from django
                 'django.template.context_processors.request',
+                'django.contrib.messages.context_processors.messages',
             ],
         },
     },


### PR DESCRIPTION
fix #504 

in the dashboard project list:
![screenshot from 2017-09-06 16-14-14](https://user-images.githubusercontent.com/26101337/30103968-7744ddbc-931e-11e7-99c8-ea5f768ad464.png)

when user registered an organisation:
![screenshot from 2017-09-06 16-19-16](https://user-images.githubusercontent.com/26101337/30104240-36afb7b2-931f-11e7-9ea8-ed99a72ee044.png)

when a new organisation is registered, an email is sent to project owner:
```
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 7bit
Subject: Projecta - New Pending Organisation Approval
From: anita@kartoza.com
To: anita@kartoza.com
Date: Wed, 06 Sep 2017 10:07:55 -0000
Message-ID: <20170906100755.2961.91902@uwsgi>

Dear Anita Hapsari,

You have a new organisation registered to your project: XProject.
You may review and approve the organisation by following this link:
0.0.0.0:61202/en/x-project/pending-certifyingorganisation/list/

Sincerely,




----------------------------------------------------------
This is an auto-generated email from the system. Please do not reply to this email.
```