### PR TITLE
fix pending page

### DIFF
--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -107,18 +107,16 @@
                             data-title="Approve {{ certifyingorganisation.name }}">
                             <span class="glyphicon glyphicon-thumbs-up"></span>
                         </a>
-                    {% endif %}
-                    {% if user.is_staff or user in certifyingorganisation.organisation_owners.all %}
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                        href='{% url "certifyingorganisation-update" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
-                        data-title="Edit {{ certifyingorganisation.name }}">
-                    <span class="glyphicon glyphicon-pencil"></span>
-                    </a>
-                    <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
-                       href='{% url "certifyingorganisation-delete" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
-                        data-title="Delete {{ certifyingorganisation.name }}">
-                        <span class="glyphicon glyphicon-minus"></span>
-                    </a>
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                            href='{% url "certifyingorganisation-update" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
+                            data-title="Edit {{ certifyingorganisation.name }}">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                        </a>
+                        <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
+                           href='{% url "certifyingorganisation-delete" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
+                            data-title="Delete {{ certifyingorganisation.name }}">
+                            <span class="glyphicon glyphicon-minus"></span>
+                        </a>
                     {% endif %}
                 </div>
             </div>

--- a/django_project/certification/templates/certifying_organisation/pending-list.html
+++ b/django_project/certification/templates/certifying_organisation/pending-list.html
@@ -101,7 +101,7 @@
             </div>
             <div class="col-lg-2">
                 <div class="btn-group pull-right">
-                    {% if not certifyingorganisation.approved and user.is_staff %}
+                    {% if not certifyingorganisation.approved and user.is_staff or user == project.owner %}
                         <a class="btn btn-default btn-mini btn-approved tooltip-toggle"
                            href='{% url "certifyingorganisation-approve" project_slug=certifyingorganisation.project.slug slug=certifyingorganisation.slug %}'
                             data-title="Approve {{ certifyingorganisation.name }}">

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -16,7 +16,7 @@ from django.views.generic import (
 from django.http import HttpResponseRedirect, Http404
 from django.db import IntegrityError
 from django.core.exceptions import ValidationError
-from braces.views import LoginRequiredMixin, StaffuserRequiredMixin
+from braces.views import LoginRequiredMixin
 from pure_pagination.mixins import PaginationMixin
 from ..models import (
     CertifyingOrganisation,
@@ -611,10 +611,11 @@ class PendingCertifyingOrganisationListView(
                         CertifyingOrganisation.unapproved_objects.filter(
                             project=self.project)
                 else:
-                    queryset = CertifyingOrganisation.unapproved_objects.filter(
-                        Q(project=self.project) &
-                        (Q(project__owner=self.request.user) |
-                         Q(organisation_owners=self.request.user)))
+                    queryset = \
+                        CertifyingOrganisation.unapproved_objects.filter(
+                            Q(project=self.project) &
+                            (Q(project__owner=self.request.user) |
+                             Q(organisation_owners=self.request.user)))
                 return queryset
             else:
                 raise Http404(

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -606,10 +606,15 @@ class PendingCertifyingOrganisationListView(
             self.project_slug = self.kwargs.get('project_slug', None)
             if self.project_slug:
                 self.project = Project.objects.get(slug=self.project_slug)
-                queryset = CertifyingOrganisation.unapproved_objects.filter(
-                    Q(project=self.project) &
-                    (Q(project__owner=self.request.user) |
-                     Q(organisation_owners=self.request.user)))
+                if self.request.user.is_staff:
+                    queryset = \
+                        CertifyingOrganisation.unapproved_objects.filter(
+                            project=self.project)
+                else:
+                    queryset = CertifyingOrganisation.unapproved_objects.filter(
+                        Q(project=self.project) &
+                        (Q(project__owner=self.request.user) |
+                         Q(organisation_owners=self.request.user)))
                 return queryset
             else:
                 raise Http404(
@@ -619,7 +624,6 @@ class PendingCertifyingOrganisationListView(
 
 class ApproveCertifyingOrganisationView(
         CertifyingOrganisationMixin,
-        StaffuserRequiredMixin,
         RedirectView):
     """Redirect view for approving Certifying Organisation."""
 

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
+from django.db.models import Q
 from django.http import HttpResponse
 from django.views.generic import (
     ListView,
@@ -606,7 +607,9 @@ class PendingCertifyingOrganisationListView(
             if self.project_slug:
                 self.project = Project.objects.get(slug=self.project_slug)
                 queryset = CertifyingOrganisation.unapproved_objects.filter(
-                    project=self.project)
+                    Q(project=self.project) &
+                    (Q(project__owner=self.request.user) |
+                     Q(organisation_owners=self.request.user)))
                 return queryset
             else:
                 raise Http404(

--- a/django_project/changes/templates/category/list.html
+++ b/django_project/changes/templates/category/list.html
@@ -85,6 +85,7 @@
                        href='{% url "category-delete" project_slug=category.project.slug slug=category.slug %}'>
                         <span class="glyphicon glyphicon-minus"></span>
                     </a>
+                    {% if category.approved %}
                     <a class="btn btn-default btn-mini"
                        href='{% url "category-update" project_slug=category.project.slug slug=category.slug %}'>
                         <span class="glyphicon glyphicon-pencil"></span>
@@ -93,6 +94,7 @@
                        href='{% url "category-detail" project_slug=category.project.slug slug=category.slug %}'>
                         <span class="glyphicon glyphicon-eye-open"></span>
                     </a>
+                    {% endif %}
                 </div>
             </div>
         </li>

--- a/django_project/changes/views/entry.py
+++ b/django_project/changes/views/entry.py
@@ -392,10 +392,10 @@ class PendingEntryListView(EntryMixin, PaginationMixin, ListView,
 
 
 class AllPendingEntryList(
+        StaffuserRequiredMixin,
         EntryMixin,
         PaginationMixin,
-        ListView,
-        StaffuserRequiredMixin):
+        ListView):
     """List view for pending Entry."""
     context_object_name = 'unapproved_entries'
     template_name = 'entry/all-pending-list.html'


### PR DESCRIPTION
fix #524 

This PR
- [x] fix pending organisation view permissions
- [x] gives permission to a project owner to approve pending organisation.

------------------------------------------------------------------------------------------------------------------------
In this example, there are 2 pending organisations.

when user is a staff or project owner:
![screenshot from 2017-09-15 10-30-42](https://user-images.githubusercontent.com/26101337/30465442-6826f718-9a01-11e7-9a28-125da33aff75.png)

when user is the organisation's owner of `test anitan` organisation:
![screenshot from 2017-09-15 10-31-06](https://user-images.githubusercontent.com/26101337/30465464-844445b8-9a01-11e7-9a42-6ceb58f1e046.png)

when user is not a staff nor creator of any pending organisation:
![screenshot from 2017-09-15 10-31-28](https://user-images.githubusercontent.com/26101337/30465488-9592b2dc-9a01-11e7-8f19-f15eaedb0d86.png)

----------------------------
This PR also removes the edit and view button in the category pending approval:
![screenshot from 2017-09-15 13-23-32](https://user-images.githubusercontent.com/26101337/30469116-2cfb8c2c-9a19-11e7-9b9f-629f6549bf51.png)

-----------------------
From what I have checked, the other pending views are already strictly only for staff, other user cannot see them. Here's what happen when a non staff user wants to see category / version / entry pending view:
![screenshot from 2017-09-15 13-27-03](https://user-images.githubusercontent.com/26101337/30469293-b3172456-9a19-11e7-82e6-d0d48dcab1c1.png)

