### PR TITLE
add function to increment slug

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -98,6 +98,7 @@ class CourseTypeForm(forms.ModelForm):
             'description',
             'instruction_hours',
             'coursetype_link',
+            'certifying_organisation',
         )
 
     def __init__(self, *args, **kwargs):
@@ -118,11 +119,13 @@ class CourseTypeForm(forms.ModelForm):
         self.helper.layout = layout
         self.helper.html5_required = False
         super(CourseTypeForm, self).__init__(*args, **kwargs)
+        self.fields['certifying_organisation'].initial = \
+            self.certifying_organisation
+        self.fields['certifying_organisation'].widget = forms.HiddenInput()
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):
         instance = super(CourseTypeForm, self).save(commit=False)
-        instance.certifying_organisation = self.certifying_organisation
         instance.author = self.user
         instance.save()
         return instance
@@ -265,7 +268,8 @@ class CourseForm(forms.ModelForm):
             'training_center',
             'start_date',
             'end_date',
-            'template_certificate'
+            'template_certificate',
+            'certifying_organisation',
         )
 
     def __init__(self, *args, **kwargs):
@@ -299,6 +303,9 @@ class CourseForm(forms.ModelForm):
         self.fields['training_center'].queryset = \
             TrainingCenter.objects.filter(
                 certifying_organisation=self.certifying_organisation)
+        self.fields['certifying_organisation'].initial = \
+            self.certifying_organisation
+        self.fields['certifying_organisation'].widget = forms.HiddenInput()
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):
@@ -379,7 +386,6 @@ class AttendeeForm(forms.ModelForm):
     def save(self, commit=True):
         instance = super(AttendeeForm, self).save(commit=False)
         instance.author = self.user
-        instance.certifying_organisation = self.certifying_organisation
         instance.save()
         return instance
 

--- a/django_project/certification/migrations/0012_auto_20170922_0649.py
+++ b/django_project/certification/migrations/0012_auto_20170922_0649.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0011_auto_20170908_1106'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='course',
+            unique_together=set([('course_convener', 'course_type', 'training_center', 'start_date', 'end_date', 'certifying_organisation')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='coursetype',
+            unique_together=set([('name', 'certifying_organisation')]),
+        ),
+    ]

--- a/django_project/certification/models/course.py
+++ b/django_project/certification/models/course.py
@@ -16,7 +16,7 @@ from unidecode import unidecode
 from core.settings.contrib import STOP_WORDS
 from course_convener import CourseConvener
 from certifying_organisation import CertifyingOrganisation
-from course_type import CourseType
+from course_type import CourseType, increment_name
 from training_center import TrainingCenter
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,9 @@ class Course(models.Model):
 
     class Meta:
         ordering = ['name']
+        unique_together = [
+            'course_convener', 'course_type', 'training_center', 'start_date',
+            'end_date', 'certifying_organisation']
 
     def save(self, *args, **kwargs):
         project_name = self.certifying_organisation.project.name
@@ -75,7 +78,9 @@ class Course(models.Model):
         self.name = \
             project_name + '_' + course_type_name + '_' + \
             str(self.start_date) + '-' + str(self.end_date)
-        words = self.name.split()
+        registered_course = Course.objects.all()
+        name = increment_name(self.name, registered_course)
+        words = name.split()
         filtered_words = [word for word in words if
                           word.lower() not in STOP_WORDS]
         # unidecode() represents special characters (unicode data) in ASCII


### PR DESCRIPTION
fix #520 

this PR:
- [x] Increment slug for course and course type when there are duplicates, so this will allows different organisation to have the same course or course type
- [x] Add unique_together for course type and certifying organisation
- [x] for course the unique_together includes course type, course convener, start date, end date, training center and certifying organisation