### PR TITLE
add send email to all attendees with paid certificate

### DIFF
--- a/django_project/certification/templates/certificate/send_email_confirm.html
+++ b/django_project/certification/templates/certificate/send_email_confirm.html
@@ -1,0 +1,27 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Send email</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <div>
+        <div class="container">
+            <h4 style="font-size: 16pt">Are you sure you want to send email for the following course attendees along with the link to their certificates?</h4>
+            <div style="border: 2px solid #f5f5f5; padding: 20px 10px 10px 10px; font-size: 12pt; margin-top: 15px">
+            <ul>
+                {% for attendee in attendees %}
+                    <li>{{ attendee }}</li>
+                {% endfor %}
+            </ul>
+            </div>
+            <h5>Note: Only course attendee with paid certificate will receive the email.</h5>
+             <form id="send-email" action="." method="POST">
+                 {% csrf_token %}
+                 <input type="submit" value="Submit" class="btn btn-primary">
+             </form>
+        </div>
+    </div>
+{% endblock %}

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -13,6 +13,28 @@
 
 {% block content %}
 
+    <style>
+        .success {
+            text-align: center;
+            font-family: inherit;
+            color: inherit;
+            background: #adffd2;
+            padding: 10px;
+            border-radius: 5px;
+            border: 1px solid #96ffc5;
+        }
+    </style>
+
+    {% if messages %}
+    <div class="messages">
+        {% for message in messages %}
+            {% if 'email_sent' in message.tags %}
+                <p{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</p>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
     <div class="row">
         <div class="col-lg-10">
         <h1>{{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})</h1><br/>
@@ -26,13 +48,13 @@
                    data-title="Delete Course">
                     <span class="glyphicon glyphicon-minus"></span>
                 </a>
-                <a class="btn btn-default btn-sm tooltip-toggle"
+                <a class="btn btn-default btn-sm tooltip-toggle btn-primary-focus"
                    href='{% url "course-update" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
                    data-title="Edit Course">
                     <span class="glyphicon glyphicon-pencil"></span>
                 </a>
             {% endif %}
-                <a class="btn btn-default btn-sm tooltip-toggle"
+                <a class="btn btn-default btn-sm tooltip-toggle btn-primary-focus"
                     href='{% url "certifyingorganisation-detail" course.certifying_organisation.project.slug course.certifying_organisation.slug %}'
                     data-title="Back">
                      <span class="glyphicon glyphicon-arrow-left"></span>
@@ -99,21 +121,25 @@
         }
     </style>
 
-    <div class="menu-wrapper details-wrapper" style="margin-left: -15px; margin-top: 50px; float: left">
-
+    <div class="menu-wrapper details-wrapper" style="margin-left: -15px; margin-top: 50px;">
     <table style="border: none!important; width: 100%">
     <tr style="border: none"><td style="border: none; padding: 0"><h3 style="margin-top: -20px">Course attendees</h3></td>
     {% if user in course.certifying_organisation.organisation_owners.all or user.is_staff or user == course.course_convener.user or user == project.owner %}
     <td style="border: none; padding: 0;">
-    <div class="btn-group pull-right">
-        <a class="btn btn-default btn-sm tooltip-toggle" style=" margin-top: -30px"
+    <div class="btn-group pull-right" style="margin-top: -30px">
+        <a class="btn btn-default btn-sm tooltip-toggle btn-info-focus"
            href='{% url 'courseattendee-create' project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
             data-title="Add Course Attendees">
             {% show_button_icon "add" %}</a>
-        <a id='download-zip' class="btn btn-default btn-sm tooltip-toggle pull-right" style=" margin-top: -30px"
+        <a id='download-zip' class="btn btn-default btn-sm tooltip-toggle"
            href='{% url "download_zip_all" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug %}'
             data-title="Download all issued certificates from this course">
             <span class="glyphicon glyphicon-download-alt"></span>
+            </a>
+         <a class="btn btn-default btn-sm tooltip-toggle btn-info-focus"
+           href='{% url "send_email" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug %}'
+            data-title="Email all participants with the link to their certificates.">
+            <i class="glyphicon glyphicon-send"></i>
             </a>
     </div>
     </td></tr>
@@ -187,8 +213,11 @@
     </div>
 
     <script>
+        $(document).click(function () {
+            $('.messages').fadeOut('fast')
+        });
 
-        $('#download-zip').hover(
+        $('#download-zip, .btn-print, .btn-info-focus').hover(
             function (){
                 $(this).removeClass('btn-default').addClass('btn-info')
             },
@@ -204,12 +233,12 @@
                 $(this).removeClass('btn-danger').addClass('btn-default')
             }
         );
-        $('.btn-print').hover(
+        $('.btn-primary-focus').hover(
             function (){
-                $(this).removeClass('btn-default').addClass('btn-info')
+                $(this).removeClass('btn-default').addClass('btn-primary')
             },
             function (){
-                $(this).removeClass('btn-info').addClass('btn-default')
+                $(this).removeClass('btn-primary').addClass('btn-default')
             }
         );
         $('.btn-issue').hover(

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -49,6 +49,7 @@ from views import (
     download_certificates_zip,
     update_paid_status,
     top_up_unavailable,
+    email_all_attendees,
 
     # Validate Certificate.
     ValidateCertificate,
@@ -185,6 +186,22 @@ urlpatterns = patterns(
               '(?P<organisation_slug>[\w-]+)/top-up/$',
         view=top_up_unavailable,
         name='top-up'),
+    url(regex='^(?P<project_slug>[\w-]+)/certificate/'
+              '(?P<id>[\w-]+)/$',
+        view=CertificateDetailView.as_view(),
+        name='certificate-details'),
+    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+        '(?P<organisation_slug>[\w-]+)/course/'
+        '(?P<course_slug>[\w-]+)/print/(?P<pk>[\w-]+)/$',
+        certificate_pdf_view, name='print-certificate'),
+    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+        '(?P<organisation_slug>[\w-]+)/course/'
+        '(?P<course_slug>[\w-]+)/download_zip/$',
+        download_certificates_zip, name='download_zip_all'),
+    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+        '(?P<organisation_slug>[\w-]+)/course/'
+        '(?P<course_slug>[\w-]+)/send_email/$',
+        email_all_attendees, name='send_email'),
 
     # Course.
     url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
@@ -201,20 +218,6 @@ urlpatterns = patterns(
               '(?P<slug>[\w-]+)/delete/$',
         view=CourseDeleteView.as_view(),
         name='course-delete'),
-
-    # Certificate.
-    url(regex='^(?P<project_slug>[\w-]+)/certificate/'
-              '(?P<id>[\w-]+)/$',
-        view=CertificateDetailView.as_view(),
-        name='certificate-details'),
-    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
-        '(?P<organisation_slug>[\w-]+)/course/'
-        '(?P<course_slug>[\w-]+)/print/(?P<pk>[\w-]+)/$',
-        certificate_pdf_view, name='print-certificate'),
-    url(r'^(?P<project_slug>[\w-]+)/certifyingorganisation/'
-        '(?P<organisation_slug>[\w-]+)/course/'
-        '(?P<course_slug>[\w-]+)/download_zip/$',
-        download_certificates_zip, name='download_zip_all'),
 
     # Search.
     url(regex='^(?P<project_slug>[\w-]+)/certificate/$',

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -2,6 +2,7 @@
 import StringIO
 import os
 import zipfile
+from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.views.generic import CreateView, DetailView
 from django.core.mail import send_mail
@@ -489,3 +490,78 @@ def top_up_unavailable(request, **kwargs):
         context={
             'the_project': project,
             'has_pending_organisations': has_pending})
+
+
+def email_all_attendees(request, **kwargs):
+    project_slug = kwargs.get('project_slug', None)
+    course_slug = kwargs.get('course_slug', None)
+    organisation_slug = kwargs.get('organisation_slug', None)
+    project = Project.objects.get(slug=project_slug)
+    course = Course.objects.get(slug=course_slug)
+    attendee_list = \
+        Certificate.objects.filter(
+            is_paid=True, course=course).values_list('attendee', flat=True)
+    attendee_list_object = []
+    for attendee_pk in attendee_list:
+        attendee = Attendee.objects.get(pk=attendee_pk)
+        attendee_list_object.append(attendee)
+
+    organisation = CertifyingOrganisation.objects.filter(approved=False)
+    has_pending = False
+    if organisation:
+        has_pending = True
+
+    url = reverse('course-detail', kwargs={
+        'project_slug': project_slug,
+        'organisation_slug': organisation_slug,
+        'slug': course_slug
+    })
+
+    if request.method == 'POST':
+
+        site = request.get_host()
+        for attendee in attendee_list_object:
+            # Send email to each attendee with the link to his certificate.
+
+            send_mail(
+                'Certificate from %s Course' % course.course_type,
+                'Dear %s %s,\n\n' % (
+                    attendee.firstname, attendee.surname) +
+                'Congratulations!\n'
+                'Your certificate from the following course '
+                'has been issued.\n\n' +
+                'Course type: %s\n' % course.course_type +
+                'Course date: %s to %s\n' % (
+                    course.start_date.strftime('%d %B %Y'),
+                    course.end_date.strftime('%d %B %Y')) +
+                'Training center: %s\n' % course.training_center +
+                'Certifying organisation: %s\n\n'
+                % course.certifying_organisation.name +
+                'You may print the certificate '
+                'by visiting:\n'
+                'http://%s/en/%s/certifyingorganisation/%s/course/'
+                '%s/print/%s/\n\n' % (
+                    site,
+                    course.certifying_organisation.project.slug,
+                    course.certifying_organisation.slug,
+                    course.slug,
+                    attendee.pk
+                ) +
+                'Sincerely,\n%s %s' % (
+                    course.course_convener.user.first_name,
+                    course.course_convener.user.last_name
+                ),
+                course.course_convener.user.email,
+                [attendee.email],
+                fail_silently=False,
+            )
+
+        messages.success(request, 'Email sent', 'email_sent')
+        return HttpResponseRedirect(url)
+
+    return render(
+        request, 'certificate/send_email_confirm.html',
+        context={
+            'the_project': project,
+            'has_pending_organisations': has_pending,
+            'attendees': attendee_list_object})


### PR DESCRIPTION
fix #545 

icon in course details page:
![screenshot from 2017-09-25 17-29-37](https://user-images.githubusercontent.com/26101337/30804314-2e694922-a217-11e7-8de0-0e2bf352c36c.png)

confirm page:
![screenshot from 2017-09-25 17-24-27](https://user-images.githubusercontent.com/26101337/30804246-da8a7c36-a216-11e7-9cbd-dec506862f03.png)

gif:
![peek 2017-09-25 17-26](https://user-images.githubusercontent.com/26101337/30804250-de65c7d4-a216-11e7-8d5b-3af8a80ff38c.gif)

email content:
```
Dear Jane Austen,

Congratulations!
Your certificate from the following course has been issued.

Course type: Coding for Dummies
Course date: 11 July 2017 to 19 December 2017
Training center: training center B
Certifying organisation: OrganisationX

You may print the certificate by visiting:
http://0.0.0.0:61202/en/x-project/certifyingorganisation/xproject-organisationx/course/xproject_coding-for-dummies_2017-07-11-2017-12-19/print/37/

Sincerely,
Anita Hapsari
```