### PR TITLE
update landing page style

### DIFF
--- a/django_project/base/static/css/project-details.css
+++ b/django_project/base/static/css/project-details.css
@@ -106,3 +106,7 @@
     border-top: 2px solid #F5F5F5;
     text-align: justify;
 }
+
+.content-list {
+    border-top: 2px solid #F5F5F5;
+}

--- a/django_project/base/templates/project/includes/project-panel.html
+++ b/django_project/base/templates/project/includes/project-panel.html
@@ -54,53 +54,6 @@
       {% endif %}
       {% if project.description %}
         <p>{{ project.description|base_markdown }}</p>
-        <hr/>
-      {% endif %}
-      <h4 class="text-muted">
-        Latest Versions
-        {% if project.approved %}
-            <a href="{% url 'version-create' project_slug=project.slug %}"
-               class="btn btn-default pull-right btn-sm tooltip-toggle"
-               data-title="Create New Version">
-              {% show_button_icon "add" %}
-            </a>
-        {% endif %}
-      </h4>
-      <hr/>
-      {% if project.versions %}
-        {% for version in project.latest_versions %}
-            {% if version.approved or user.is_authenticated %}
-              <p>
-                  {% if version.approved %}
-                    <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}">
-                    <strong><span class="text-muted">Version:</span> {{ version.name }}</strong>
-                    </a>
-                  {% else %}
-                    <a href="{% url "pending-version-list" version.project.slug%}">
-                    <strong><span class="text-muted">Version:</span> {{ version.name }}</strong> <b  class="text-muted">(pending)</b>
-                    </a>
-                  {% endif %}
-                <span class="btn-group pull-right">
-                  <a href="{% url "version-detail" project_slug=version.project.slug slug=version.slug %}"
-                      class="btn btn-default btn-xs tooltip-toggle"
-                      data-placement="top" data-title="Changelog List">
-                    <span class="glyphicon glyphicon-list"></span>
-                  </a>
-                  <a href="{% url "version-thumbs" project_slug=version.project.slug slug=version.slug %}"
-                     class="btn btn-default btn-xs tooltip-toggle"
-                     data-placement="top" data-title="Changelog Thumbs">
-                    <span class="glyphicon glyphicon-th"></span>
-                  </a>
-                </span>
-              </p>
-            {% endif %}
-        {% endfor %}
-          {% if project.more_than_threshold %}
-              <strong><span class="text-muted">Latest {{ project.threshold }} of {{ project.versions.count }} versionss</span></strong>
-          {% endif %}
-          {% if not project.more_than_threshold %}
-              <strong><span class="text-muted">Latest {{ project.versions.count }} of {{ project.versions.count }} versions</span></strong>
-          {% endif %}
       {% endif %}
     </div>
   </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -56,7 +56,7 @@
                 <h3>Sponsors</h3>
             {% if sponsors %}
                 <h4 class="text-muted">
-                        View our project sponsors
+                        View Our Project Sponsors
                 </h4>
                 <div class="content-list">
                 {% for sponsor in sponsors %}

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -67,6 +67,11 @@
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='certifyingorganisation/list/';">
                 <h3>Certification</h3>
+                {% if organisations %}
+                    {% for organisation in organisations %}
+                        <h5><strong>{{ organisation.name }}</strong></h5>
+                    {% endfor %}
+                {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
                 <h3>Releases (Changelog)</h3>
@@ -88,7 +93,7 @@
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='committees/';">
                 <h3>Project Teams</h3>
                 {% for team in committees %}
-                    <p><strong><span>{{ team.name }}</span></strong></p>
+                    <h5><strong><span>{{ team.name }}</span></strong></h5>
                 {% endfor %}
             </div>
         </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -54,6 +54,11 @@
         <div class="col-md-4">
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='sponsors/list/';">
                 <h3>Sponsors</h3>
+            {% if sponsors %}
+                <h4 class="text-muted">
+                        View our project sponsors
+                </h4>
+                <div class="content-list">
                 {% for sponsor in sponsors %}
                     {% if sponsor.current_sponsor %}
                         {% ifchanged sponsor.sponsorship_level %}
@@ -64,20 +69,27 @@
                                  data-title="{{ sponsor.sponsor.name }}">
                     {% endif %}
                 {% endfor %}
+                </div>
+            {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='certifyingorganisation/list/';">
                 <h3>Certification</h3>
                 {% if organisations %}
+                    <h4 class="text-muted">
+                    Certifying Organisations
+                    </h4>
+                    <div class="content-list">
                     {% for organisation in organisations %}
                         <h5><strong>{{ organisation.name }}</strong></h5>
                     {% endfor %}
+                    </div>
                 {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
                 <h3>Releases (Changelog)</h3>
                 {% if versions %}
                 <h4 class="text-muted">
-                    Latest Versions
+                    New Features and Releases
                   </h4>
                     <div class="version-list">
                     {% for version in versions %}
@@ -92,9 +104,16 @@
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='committees/';">
                 <h3>Project Teams</h3>
-                {% for team in committees %}
-                    <h5><strong><span>{{ team.name }}</span></strong></h5>
-                {% endfor %}
+                {% if committees %}
+                    <h4 class="text-muted">
+                    Collaborate and Decide
+                  </h4>
+                    <div class="content-list">
+                        {% for team in committees %}
+                            <h5><strong><span>{{ team.name }}</span></strong></h5>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -134,6 +134,9 @@ class ProjectDetailView(ProjectMixin, DetailView):
             SponsorshipPeriod.objects.filter(
                 project=self.object).order_by('-sponsorship_level__value')
         context['screenshots'] = self.object.screenshots.all()
+        context['organisations'] = \
+            CertifyingOrganisation.objects.filter(
+                project=self.object, approved=True)
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
fix #564 

This PR:
- [x] update home page style
- [x] add list organisations in the project landing page

home page:
![screenshot from 2017-10-05 16-58-50](https://user-images.githubusercontent.com/26101337/31221869-4714a824-a9ef-11e7-90da-ad313cf1a3d2.png)
![screenshot from 2017-10-05 17-01-18](https://user-images.githubusercontent.com/26101337/31221870-47cdede8-a9ef-11e7-8847-c04a841e8b46.png)

project landing page:
![screenshot from 2017-10-05 16-58-30](https://user-images.githubusercontent.com/26101337/31221885-54e6001a-a9ef-11e7-8338-889f656b2004.png)
