### PR TITLE
changed side block title from 'Releases (Changelogs)' to 'Release Changelogs'

### DIFF
--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -90,7 +90,7 @@
                 {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
-                <h3>Releases (Changelog)</h3>
+                <h3>Release Changelogs</h3>
                 {% if versions %}
                 <h4 class="text-muted">
                     New Features and Releases


### PR DESCRIPTION
See #579

![screenshot from 2017-10-10 19 02 16](https://user-images.githubusercontent.com/10270148/31408368-90da6cec-ae08-11e7-8460-4c59faaf84dd.png)
