### PR TITLE
Fix failing tests due to client login not working

### DIFF
--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -28,6 +28,11 @@ class TestViews(TestCase):
             'username': 'timlinux',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
         self.user.set_password('password')
         self.user.save()
 

--- a/django_project/changes/tests/test_views.py
+++ b/django_project/changes/tests/test_views.py
@@ -42,6 +42,13 @@ class TestCategoryViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """
@@ -62,10 +69,11 @@ class TestCategoryViews(TestCase):
 
     def test_CategoryCreateView_with_login(self):
 
-        self.client.login(username='timlinux', password='password')
-        response = self.client.get(reverse('category-create', kwargs={
-            'project_slug': self.project.slug
-        }))
+        status = self.client.login(username='timlinux', password='password')
+        self.assertTrue(status)
+        url = reverse(
+            'category-create', kwargs={'project_slug': self.project.slug})
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         expected_templates = [
             'category/create.html'
@@ -273,6 +281,13 @@ class TestEntryViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """
@@ -506,6 +521,13 @@ class TestVersionViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """
@@ -717,6 +739,13 @@ class TestSponsorshipLevelViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """
@@ -862,6 +891,13 @@ class TestSponsorViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """
@@ -1010,6 +1046,13 @@ class TestSponsorshipPeriodViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
 
     def tearDown(self):
         """

--- a/django_project/vota/tests/test_views.py
+++ b/django_project/vota/tests/test_views.py
@@ -25,6 +25,14 @@ class TestVoteViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
+
         self.project = ProjectF.create()
         self.committee = CommitteeF.create(project=self.project,
                                              users=[self.user])
@@ -97,6 +105,14 @@ class TestBallotViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
+
         self.project = ProjectF.create()
         self.committee = CommitteeF.create(project=self.project,
                                              users=[self.user])
@@ -333,6 +349,14 @@ class TestCommitteeViews(TestCase):
             'password': 'password',
             'is_staff': True
         })
+        # Something changed in the way factoryboy works with django 1.8
+        # I think - we need to explicitly set the users password
+        # because the core.model_factories.UserF._prepare method
+        # which sets the password is never called. Next two lines are
+        # a work around for that - sett #581
+        self.user.set_password('password')
+        self.user.save()
+
         self.project = ProjectF.create()
         self.committee = CommitteeF.create(project=self.project,
                                              users=[self.user])


### PR DESCRIPTION
See #581 



This commit fixes issues with tests that require a logged in user.

I fixed the issues by adding lines like this in each place where we use the user factory:

        # Something changed in the way factoryboy works with django 1.8
        # I think - we need to explicitly set the users password
        # because the core.model_factories.UserF._prepare method
        # which sets the password is never called. Next two lines are
        # a work around for that - sett #581
        self.user.set_password('password')
        self.user.save()

There are still some tests failing due to missing css and js libs - will try to address those in a separate PR.

Fix #581

Signed-off-by: Tim Sutton <tim@kartoza.com>



Before fix:

![screen shot 2017-10-10 at 23 28 20](https://user-images.githubusercontent.com/178003/31411721-cd766ebc-ae12-11e7-9b6a-d4f9e38628f7.png)
![screen shot 2017-10-10 at 23 28 32](https://user-images.githubusercontent.com/178003/31411723-cff947fe-ae12-11e7-9951-9228ab748616.png)



After fix:


![screen shot 2017-10-10 at 23 24 51](https://user-images.githubusercontent.com/178003/31411661-9257f814-ae12-11e7-87d5-62dafa69da2e.png)

![screen shot 2017-10-10 at 23 25 03](https://user-images.githubusercontent.com/178003/31411667-952f4740-ae12-11e7-9d33-6482ab6851aa.png)
