### PR TITLE
add sponsor cloud

### DIFF
--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -20,6 +20,7 @@
                        href='{% url "sponsor-create" project_slug %}'
                        data-title="Create New Sponsor">
                         {% show_button_icon "add" %}
+                    </a>
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsor-list" project_slug %}'
@@ -27,6 +28,11 @@
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% endif %}
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       href='{% url "sponsor-cloud" project_slug %}'
+                       data-title="Generate Current Sponsor Cloud">
+                        <i class="glyphicon glyphicon-cloud"></i>
+                    </a>
                 </div>
             {% endif %}
         </h1>

--- a/django_project/changes/templates/sponsor/sponsor_cloud.html
+++ b/django_project/changes/templates/sponsor/sponsor_cloud.html
@@ -1,0 +1,28 @@
+{% extends "project_base.html" %}
+{% load custom_markup %}
+
+{% block title %}Sponsor Cloud{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+    <h1>Sponsor Cloud</h1>
+{% endblock page_title %}
+
+{% block content %}
+    {% if image != 'none' %}
+    <div>
+        <h4>To download the image, right click on the image and choose <strong>save image as</strong>.</h4>
+    </div>
+    {% endif %}
+
+    <div style="margin: 30px auto; text-align: center">
+    {% if image != 'none' %}
+        <img style="border: 2px solid #F5F5F5" src="{{ MEDIA_URL }}{{ image }}">
+    {% else %}
+        <h3>No current sponsor found</h3>
+    {% endif %}
+    </div>
+
+{% endblock %}

--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -74,6 +74,8 @@ from views import (
     SponsorshipPeriodUpdateView,
     PendingSponsorshipPeriodListView,
     ApproveSponsorshipPeriodView,
+
+    generate_sponsor_cloud,
 )
 
 urlpatterns = patterns(
@@ -293,6 +295,11 @@ urlpatterns = patterns(
     url(regex='^(?P<project_slug>[\w-]+)/sponsorshipperiod/(?P<slug>[\w-]+)/update/$',
         view=SponsorshipPeriodUpdateView.as_view(),
         name='sponsorshipperiod-update'),
+
+    # Sponsor Cloud
+    url(regex='^(?P<project_slug>[\w-]+)/sponsor-cloud/$',
+        view=generate_sponsor_cloud,
+        name='sponsor-cloud'),
 )
 
 

--- a/django_project/changes/views/sponsor.py
+++ b/django_project/changes/views/sponsor.py
@@ -609,7 +609,8 @@ def generate_sponsor_cloud(request, **kwargs):
             os.makedirs(filepath)
 
         background.crop(
-            (0, 0, max_x, max_y)).save(filepath + '{}.png'.format(project_name))
+            (0, 0, max_x, max_y)).save(
+            filepath + '{}.png'.format(project_name))
 
         image_path = '/images/sponsors/{}.png'.format(project_name)
 

--- a/django_project/changes/views/sponsor.py
+++ b/django_project/changes/views/sponsor.py
@@ -1,12 +1,13 @@
 __author__ = 'rischan'
 
 
+import os
 import logging
 from base.models import Project
 
-
+from PIL import Image
 from django.core.urlresolvers import reverse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.http import HttpResponse
 from django.views.generic import (
     ListView,
@@ -555,3 +556,65 @@ class ApproveSponsorView(SponsorMixin, StaffuserRequiredMixin, RedirectView):
         return reverse(self.pattern_name, kwargs={
             'project_slug': project_slug
         })
+
+
+def generate_sponsor_cloud(request, **kwargs):
+    """Generate image for sponsor logos."""
+
+    project_slug = kwargs.pop('project_slug')
+    project = Project.objects.get(slug=project_slug)
+    project_name = project.name.lower().replace(' ', '_')
+    queryset = SponsorshipPeriod.objects.filter(
+        project=project).order_by('-sponsorship_level__value')
+    background = Image.new("RGB", (1200, 1000), "white")
+    max_x = 0
+    max_y = 0
+    y = 0
+    x = 0
+    sponsor_level = ''
+    xy_size = 100
+    for sponsor in queryset:
+        if sponsor.current_sponsor():
+            if sponsor.sponsorship_level.name != sponsor_level:
+                if sponsor_level != '':
+                    sponsor_level = sponsor.sponsorship_level.name
+                    xy_size -= 25
+                    y += 25
+                    if xy_size < 25:
+                        xy_size = 25
+                        y -= 25
+                else:
+                    sponsor_level = sponsor.sponsorship_level.name
+
+            im = Image.open(
+                sponsor.sponsor.logo).convert("RGBA")
+            size = xy_size, xy_size
+            im.thumbnail(size, Image.ANTIALIAS)
+            width, height = im.size
+            if (x + xy_size) >= 1000:
+                x = 0
+                y += xy_size
+            if max_x <= (x + xy_size):
+                max_x = x + xy_size
+            if max_y <= y:
+                max_y = y + xy_size
+            background.paste(
+                im, box=(x, y + ((xy_size - height) / 2)), mask=im)
+            x += xy_size
+
+    image_path = 'none'
+    if max_x != 0:
+        filepath = '/home/web/media/images/sponsors/'
+        if not os.path.exists(filepath):
+            os.makedirs(filepath)
+
+        background.crop(
+            (0, 0, max_x, max_y)).save(filepath + '{}.png'.format(project_name))
+
+        image_path = '/images/sponsors/{}.png'.format(project_name)
+
+    return render(
+        request, 'sponsor/sponsor_cloud.html',
+        context={
+            'image': image_path,
+            'the_project': project})


### PR DESCRIPTION
fix #230 

The button in the sponsors page:
![screenshot from 2017-10-11 14-03-38](https://user-images.githubusercontent.com/26101337/31426355-31f41bbc-ae8d-11e7-9937-9815512528ae.png)

Page showing the generated image:
![screenshot from 2017-10-11 14-03-49](https://user-images.githubusercontent.com/26101337/31426384-54cdaa22-ae8d-11e7-9aeb-d5cf487db1df.png)

4 icon sizes are available depending on the rank of the sponsorship level in the current sponsors: 100px, 75px, 50px and 25px.
![screenshot from 2017-10-11 14-04-30](https://user-images.githubusercontent.com/26101337/31426428-82acc5e0-ae8d-11e7-8b34-862d6d7396c3.png)

When current sponsor is not available:
![screenshot from 2017-10-11 14-04-04](https://user-images.githubusercontent.com/26101337/31426438-8be9f2f4-ae8d-11e7-9dd6-ebfdcf3819dd.png)
