### PR TITLE
add sponsorship programme

### DIFF
--- a/django_project/base/forms.py
+++ b/django_project/base/forms.py
@@ -54,6 +54,7 @@ class ProjectForm(forms.ModelForm):
             'signature',
             'credit_cost',
             'certificate_credit',
+            'sponsorship_programme',
         )
 
     def __init__(self, *args, **kwargs):
@@ -71,6 +72,7 @@ class ProjectForm(forms.ModelForm):
                 Field('signature', css_class="form-control"),
                 Field('credit_cost', css_class="form-control"),
                 Field('certificate_credit', css_class="form-control"),
+                Field('sponsorship_programme', css_class="form-control"),
                 Field('gitter_room', css_class="form-control"),
                 css_id='project-form')
         )

--- a/django_project/base/migrations/0008_project_sponsorship_programme.py
+++ b/django_project/base/migrations/0008_project_sponsorship_programme.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0007_project_project_url'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='sponsorship_programme',
+            field=models.TextField(help_text='Sponsorship programme for this project. Markdown is supported', max_length=3000, null=True, blank=True),
+        ),
+    ]

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -139,6 +139,15 @@ class Project(models.Model):
         blank=True,
         null=True
     )
+
+    sponsorship_programme = models.TextField(
+        help_text=_(
+            'Sponsorship programme for this project. Markdown is supported'),
+        max_length=3000,
+        blank=True,
+        null=True
+    )
+
     owner = models.ForeignKey(User)
     slug = models.SlugField(unique=True)
     objects = models.Manager()

--- a/django_project/base/templates/project/programme.html
+++ b/django_project/base/templates/project/programme.html
@@ -1,0 +1,41 @@
+{% extends "project_base.html" %}
+{% load custom_markup %}
+
+{% block title %}Sponsors Programme - {{ block.super }}{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+    <h1>Sponsors Programme</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <div class="page-header">
+        <h1 class="text-muted">Sponsorship Programme
+        <div class="pull-right btn-group">
+            {% if user.is_staff or user == the_project.owner %}
+                <a href="{% url 'project-update' the_project.slug %}"
+                   class="btn btn-default btn-m tooltip-toggle btn-edit"
+                   data-placement="top" data-title="Update">
+                  <span class="glyphicon glyphicon-pencil"></span>
+                </a>
+            {% endif %}
+            </div>
+        </h1>
+    </div>
+    <div>
+    {% if the_project.sponsorship_programme %}
+    {{ the_project.sponsorship_programme|base_markdown }}
+    {% else %}
+        {% if user.is_staff or user == the_project.owner %}
+            <h4>No sponsorship programme descriptions are available for this project. But you can
+                <a
+                    class="btn btn-default btn-mini"
+                    href='{% url 'project-update' the_project.slug %}'>add here</a>.</h4>
+        {% else %}
+            <h4>No descriptions are available.</h4>
+        {% endif %}
+    {% endif %}
+    </div>
+{% endblock %}

--- a/django_project/base/urls.py
+++ b/django_project/base/urls.py
@@ -17,7 +17,8 @@ from views import (
     GithubListView,
     GithubOrgsView,
     GithubSubmitView,
-    custom_404
+    custom_404,
+    project_sponsor_programme,
 )
 
 urlpatterns = patterns(
@@ -67,6 +68,9 @@ urlpatterns = patterns(
     url(regex='^project/submit-github-repo/$',
         view=GithubSubmitView.as_view(),
         name='submit-github-repo'),
+    url(regex='^(?P<slug>[\w-]+)/sponsorship-programme/$',
+        view=project_sponsor_programme,
+        name='sponsor-programme'),
 )
 
 # Prevent cloudflare from showing an ad laden 404 with no context

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -293,7 +293,7 @@ class ApproveProjectView(StaffuserRequiredMixin, ProjectMixin, RedirectView):
 
 def project_sponsor_programme(request, **kwargs):
     """Sponsorship programme view of a project."""
-    
+
     project_slug = kwargs.get('slug', None)
     project = Project.objects.get(slug=project_slug)
 

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -4,7 +4,7 @@
 import logging
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.views.generic import (
     ListView,
     CreateView,
@@ -289,3 +289,14 @@ class ApproveProjectView(StaffuserRequiredMixin, ProjectMixin, RedirectView):
         project.approved = True
         project.save()
         return reverse(self.pattern_name)
+
+
+def project_sponsor_programme(request, **kwargs):
+    """Sponsorship programme view of a project."""
+    
+    project_slug = kwargs.get('slug', None)
+    project = Project.objects.get(slug=project_slug)
+
+    return render(
+        request, 'project/programme.html',
+        context={'the_project': project})

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -14,12 +14,13 @@
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}Sponsors
-            {% if user.is_authenticated %}
                 <div class="pull-right btn-group">
+                {% if user.is_authenticated %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "sponsor-create" project_slug %}'
                        data-title="Create New Sponsor">
                         {% show_button_icon "add" %}
+                    </a>
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsor-list" project_slug %}'
@@ -27,8 +28,12 @@
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% endif %}
+                {% endif %}
+                    <a class="btn btn-default btn-mini tooltip-toggle"
+                       href='{% url "sponsor-programme" project_slug %}'
+                       data-title="View Sponsorship Programme">
+                        <i class="glyphicon glyphicon-info-sign"></i></a>
                 </div>
-            {% endif %}
         </h1>
     </div>
     {% ifequal num_sponsors 0 %}

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -68,10 +68,17 @@
              <div class="row" style="margin-top:10px;">
                     <div class="col-lg-1">
                         {% if sponsor.sponsor.logo %}
-                            <a href="{{ MEDIA_URL }}{{ sponsor.sponsor.logo }}">
+                            {% if sponsor.sponsor.sponsor_url %}
+                                <a href="{{ sponsor.sponsor.sponsor_url }}">
                                 <img class="img-responsive img-rounded pull-right"
                                      src="{% thumbnail sponsor.sponsor.logo 50x50 crop %}"/>
                             </a>
+                            {% else %}
+                                <a href="{{ MEDIA_URL }}{{ sponsor.sponsor.logo }}">
+                                    <img class="img-responsive img-rounded pull-right"
+                                         src="{% thumbnail sponsor.sponsor.logo 50x50 crop %}"/>
+                                </a>
+                            {% endif %}
                         {% endif %}
 
                     </div>


### PR DESCRIPTION
fix #219 

Button to view sponsorship programme in a project:
when user is logged in
![screenshot from 2017-10-11 17-46-10](https://user-images.githubusercontent.com/26101337/31436796-43af7480-aead-11e7-8d83-4da9cf6bf39d.png)
when user is not logged in
![screenshot from 2017-10-11 17-47-35](https://user-images.githubusercontent.com/26101337/31436799-44c3ad82-aead-11e7-88b5-acc767553467.png)

### Sponsorship programme page
When empty
For staff user and project owner:
![screenshot from 2017-10-11 17-43-02](https://user-images.githubusercontent.com/26101337/31436857-63674014-aead-11e7-87a1-194f497edb4e.png)

for other users:
![screenshot from 2017-10-11 17-57-05](https://user-images.githubusercontent.com/26101337/31436943-bbd8d5fa-aead-11e7-8d86-b8e83d24156c.png)


When is not empty
for staff user and project owner
![screenshot from 2017-10-11 17-46-52](https://user-images.githubusercontent.com/26101337/31436956-c9c82ef4-aead-11e7-9be8-40006538dfc7.png)

for other users:
![screenshot from 2017-10-11 17-46-21](https://user-images.githubusercontent.com/26101337/31437038-15ca292e-aeae-11e7-82e3-d6f295172fd9.png)


### form
![screenshot from 2017-10-11 17-44-08](https://user-images.githubusercontent.com/26101337/31437057-29f455f0-aeae-11e7-9068-85ebbdf21d5d.png)
![screenshot from 2017-10-11 17-44-28](https://user-images.githubusercontent.com/26101337/31437059-2aeaeb72-aeae-11e7-9a92-339e8da6c278.png)
![screenshot from 2017-10-11 17-44-57](https://user-images.githubusercontent.com/26101337/31437061-2c301188-aeae-11e7-811f-ac5b372b06b9.png)
![screenshot from 2017-10-11 17-45-32](https://user-images.githubusercontent.com/26101337/31437063-2d92e672-aeae-11e7-9468-50e09d6acf5d.png)
![screenshot from 2017-10-11 17-45-42](https://user-images.githubusercontent.com/26101337/31437067-2f7b62e8-aeae-11e7-9121-c78141267100.png)

