### PR TITLE
make sponsor programme field longer

### DIFF
--- a/django_project/base/migrations/0010_auto_20171027_0525.py
+++ b/django_project/base/migrations/0010_auto_20171027_0525.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0009_project_certification_manager'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='sponsorship_programme',
+            field=models.TextField(help_text='Sponsorship programme for this project. Markdown is supported', max_length=10000, null=True, blank=True),
+        ),
+    ]

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -143,7 +143,7 @@ class Project(models.Model):
     sponsorship_programme = models.TextField(
         help_text=_(
             'Sponsorship programme for this project. Markdown is supported'),
-        max_length=3000,
+        max_length=10000,
         blank=True,
         null=True
     )


### PR DESCRIPTION
fix #624 

I copied the content from here as example: http://www.qgis.org/en/site/getinvolved/governance/sponsorship/sponsorship.html

![screencapture-0-0-0-0-61202-en-qgis-sponsorship-programme-1509077004929](https://user-images.githubusercontent.com/26101337/32087526-84106f42-bb06-11e7-98f8-5dff8c1a5269.png)
