### PR TITLE
Hide organisational private related details from non-logged in user.

### DIFF
--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -71,47 +71,48 @@
     </div>
 
     <div class="row" style="margin-left: inherit; margin-top: 15px;">
-    <div class="details col-lg-10" style="width: 60%">
-        <span class="grey-italic col-lg-3">Course name</span><span class="col-lg-9">{{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})<br/></span>
-        <span class="grey-italic col-lg-3">Course type</span><span class="col-lg-9">{{ course.course_type }}<br/></span>
-        <span class="grey-italic col-lg-3">Course convener</span>
-        {% if course.course_convener.user.first_name %}
-        <span class="col-lg-9">{{ course.course_convener.user.first_name }} {{ course.course_convener.user.last_name }}<br/></span>
-        {% else %}
-        <span class="col-lg-9">{{ course.course_convener }}<br/></span>
-        {% endif %}
-        <span class="grey-italic col-lg-3">Training center</span><span class="col-lg-9">{{ course.training_center }}<br/></span>
-        <span class="grey-italic col-lg-3">Organisation</span><span class="col-lg-9">{{ course.certifying_organisation.name }}<br/></span>
-        <span class="grey-italic col-lg-3">Start date</span><span class="col-lg-9">{{ course.start_date }}<br/></span>
-        <span class="grey-italic col-lg-3">End date</span><span class="col-lg-9">{{ course.end_date }}<br/></span>
-    </div>
+        {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
+            <div class="details col-lg-10" style="width: 60%">
+                <span class="grey-italic col-lg-3">Course name</span><span class="col-lg-9">{{ course.course_type.name }} ({{ course.start_date }} to {{ course.end_date }})<br/></span>
+                <span class="grey-italic col-lg-3">Course type</span><span class="col-lg-9">{{ course.course_type }}<br/></span>
+                <span class="grey-italic col-lg-3">Course convener</span>
+                {% if course.course_convener.user.first_name %}
+                    <span class="col-lg-9">{{ course.course_convener.user.first_name }} {{ course.course_convener.user.last_name }}<br/></span>
+                    {% else %}
+                    <span class="col-lg-9">{{ course.course_convener }}<br/></span>
+                {% endif %}
+                    <span class="grey-italic col-lg-3">Training center</span><span class="col-lg-9">{{ course.training_center }}<br/></span>
+                    <span class="grey-italic col-lg-3">Organisation</span><span class="col-lg-9">{{ course.certifying_organisation.name }}<br/></span>
+                    <span class="grey-italic col-lg-3">Start date</span><span class="col-lg-9">{{ course.start_date }}<br/></span>
+                    <span class="grey-italic col-lg-3">End date</span><span class="col-lg-9">{{ course.end_date }}<br/></span>
+            </div>
 
-    <div class="col-lg-2 pull-right" style="width: 20%;">
-        <h4 class="panel-heading" style="padding-left:10px; padding-right: 10px">
-            Available Credits
-            {% if user in course.certifying_organisation.organisation_owners.all or user.is_staff or user == course.course_convener.user or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
-            <a class="btn btn-default btn-xs tooltip-toggle btn-top-up" style="float: right; margin-top: -3px"
-               href= '{% url "top-up" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug %}'
-                data-title="Top up credits">
-                <i class="glyphicon glyphicon-shopping-cart"></i></a>
-            {% endif %}</h4>
-        {% if course.certifying_organisation.organisation_credits >= course.certifying_organisation.project.certificate_credit %}
-        <h3 class="panel-body tooltip-toggle"
-            data-title="Available credits to issue certificate"
-            data-placement="left"
-        >{{ course.certifying_organisation.organisation_credits }}
-        </h3>
-        {% else %}
-        <h3 class="panel-body tooltip-toggle"
-            data-title="Your credits is insufficient to issue more certificates, please top up"
-            data-placement="left"
-            style="color: indianred"
-        >{{ course.certifying_organisation.organisation_credits }}
-        </h3>
+            <div class="col-lg-2 pull-right" style="width: 20%;">
+                <h4 class="panel-heading" style="padding-left:10px; padding-right: 10px">
+                    Available Credits
+                {% if user in course.certifying_organisation.organisation_owners.all or user.is_staff or user == course.course_convener.user or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
+                    <a class="btn btn-default btn-xs tooltip-toggle btn-top-up" style="float: right; margin-top: -3px"
+                       href= '{% url "top-up" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug %}'
+                        data-title="Top up credits">
+                        <i class="glyphicon glyphicon-shopping-cart"></i></a>
+                {% endif %}</h4>
+                {% if course.certifying_organisation.organisation_credits >= course.certifying_organisation.project.certificate_credit %}
+                        <h3 class="panel-body tooltip-toggle"
+                            data-title="Available credits to issue certificate"
+                            data-placement="left"
+                        >{{ course.certifying_organisation.organisation_credits }}
+                        </h3>
+                    {% else %}
+                        <h3 class="panel-body tooltip-toggle"
+                            data-title="Your credits is insufficient to issue more certificates, please top up"
+                            data-placement="left"
+                            style="color: indianred"
+                        >{{ course.certifying_organisation.organisation_credits }}
+                        </h3>
+                {% endif %}
+            </div>
         {% endif %}
     </div>
-    </div>
-
 
     <div class="container">
 


### PR DESCRIPTION
Fix #629

Do not show organisational related private details to non organisational owners or staff or admin users.

![screenshot from 2017-12-01 15 14 55](https://user-images.githubusercontent.com/10270148/33484316-6de1a6d6-d6aa-11e7-81ea-3ed8eaf55f05.png)

