### PR TITLE
add organisation name and country to email notification

### DIFF
--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -437,7 +437,9 @@ class CertifyingOrganisationCreateView(
                     'recipient_lastname': recipient.last_name,
                     'project_name': self.project.name,
                     'site': site,
-                    'project_slug': self.project_slug
+                    'project_slug': self.project_slug,
+                    'organisation_name': self.object.name,
+                    'organisation_country': self.object.country.name,
                 }
 
                 # Send email notification to project owner and
@@ -447,6 +449,8 @@ class CertifyingOrganisationCreateView(
                     'Dear {recipient_firstname} {recipient_lastname},\n\n'
                     'You have a new organisation registered to your project: '
                     '{project_name}.\n'
+                    'Organisation name: {organisation_name}\n'
+                    'Country: {organisation_country}\n'
                     'You may review and approve the organisation by following '
                     'this link:\n'
                     '{site}/en/{project_slug}/pending-certifyingorganisation/'


### PR DESCRIPTION
In console:
```
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: 7bit
Subject: Projecta - New Pending Organisation Approval
From: anita@kartoza.com
To: anita@kartoza.com
Date: Mon, 04 Dec 2017 08:24:22 -0000
Message-ID: <20171204082422.254.73420@uwsgi>

Dear Anita Hapsari,

You have a new organisation registered to your project: XProject.
Organisation name: New Organisation Submitted
Country: Indonesia
You may review and approve the organisation by following this link:
0.0.0.0:61202/en/x-project/pending-certifyingorganisation/list/

Sincerely,




-------------------------------------------------------
This is an auto-generated email from the system. Please do not reply to this email.
```