### PR TITLE
Add call to action only to project owner or staff user.

### DIFF
--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -162,10 +162,10 @@
                     </div>
                     {% else %}
                     {% if user.is_staff or user == project.owner %}
-                        <h6>No teams are defined, but you can
+                        <h6><span id="sent">No teams are defined, but you can</span>
                             <a
                                 class="btn btn-default btn-mini" id="action_text"
-                                href='{% url "committee-create" project.slug %}'>create one
+                                href='{% url "committee-create" project.slug %}'> create one
                             </a>
                         </h6>
                     {% endif %}
@@ -179,9 +179,13 @@
         font-weight: bold;
         padding: 4px;
         /*float: right;*/
+
+
+        /*position: relative;*/
     }
     h6 {
-
+    white-space: pre-line;
+    /*text-align: inherit;*/
     }
     </style>
     <script>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -131,7 +131,7 @@
                     {% if user.is_staff or user == project.owner %}
                         <h6>No versions are defined, but you can <a
                         class="btn btn-default btn-mini" id="action_text"
-                        href='#'>create one</a></h6>
+                        href='{% url "version-create" project.slug %}'>create one</a></h6>
                     {% endif %}
                 {% endif %}
             </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -87,6 +87,12 @@
                         <h5>{{ organisation.name }}</h5>
                     {% endfor %}
                     </div>
+                    {% else %}
+                        {% if user.is_staff or user == project.owner %}
+                            <h5>No teams are defined, but you can <a
+                                    class="btn btn-default btn-mini"
+                                    href='#'>create one</a></h5>
+                        {% endif %}
                 {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
@@ -122,9 +128,7 @@
                         <h5>No teams are defined, but you can <a
                                 class="btn btn-default btn-mini"
                                 href='#'>create one</a></h5>
-                                
                     {% endif %}
-
                 {% endif %}
             </div>
         </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -87,9 +87,12 @@
                 </div>
             {% else %}
                 {% if user.is_staff or user == project.owner %}
-                    <h6>No sponsors are defined, but you can <a
-                    class="btn btn-default btn-mini" id="action_text"
-                    href='{% url "sponsor-create" project.slug %}'>create one</a></h6>
+                    <h6>No sponsors are defined, but you can
+                        <a
+                            class="btn btn-default btn-mini" id="action_text"
+                            href='{% url "sponsor-create" project.slug %}'>create one
+                        </a>
+                    </h6>
                 {% endif %}
             {% endif %}
             </div>
@@ -106,9 +109,12 @@
                     </div>
                 {% else %}
                     {% if user.is_staff or user == project.owner %}
-                        <h6>No certifying organisation are defined, but you can <a
+                        <h6>No certifying organisation are defined, but you can
+                            <a
                                 class="btn btn-default btn-mini" id="action_text"
-                                href='{% url "certifyingorganisation-create" project.slug %}'>register one</a></h6>
+                                href='{% url "certifyingorganisation-create" project.slug %}'>register one
+                            </a>
+                        </h6>
                     {% endif %}
                 {% endif %}
             </div>
@@ -129,9 +135,12 @@
                     </div>
                 {% else %}
                     {% if user.is_staff or user == project.owner %}
-                        <h6>No versions are defined, but you can <a
-                        class="btn btn-default btn-mini" id="action_text"
-                        href='{% url "version-create" project.slug %}'>create one</a></h6>
+                        <h6>No versions are defined, but you can
+                            <a
+                                class="btn btn-default btn-mini" id="action_text"
+                                href='{% url "version-create" project.slug %}'>create one
+                            </a>
+                        </h6>
                     {% endif %}
                 {% endif %}
             </div>
@@ -148,9 +157,12 @@
                     </div>
                     {% else %}
                     {% if user.is_staff or user == project.owner %}
-                        <h5>No teams are defined, but you can <a
+                        <h6>No teams are defined, but you can
+                            <a
                                 class="btn btn-default btn-mini" id="action_text"
-                                href='{% url "committee-create" project.slug %}'>create one</a></h5>
+                                href='{% url "committee-create" project.slug %}'>create one
+                            </a>
+                        </h6>
                     {% endif %}
                 {% endif %}
             </div>
@@ -161,7 +173,9 @@
         font-size: 8px;
         font-weight: bold;
         padding: 3px;
-        float: right;
+    }
+    h6 {
+        float: center;
     }
     </style>
     <script>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -178,14 +178,9 @@
         font-size: 8px;
         font-weight: bold;
         padding: 4px;
-        /*float: right;*/
-
-
-        /*position: relative;*/
     }
     h6 {
     white-space: pre-line;
-    /*text-align: inherit;*/
     }
     </style>
     <script>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -69,6 +69,7 @@
         <div class="col-md-4">
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='sponsors/list/';">
                 <h3>Sponsors</h3>
+                <hr />
             {% if sponsors %}
                 <h4 class="text-muted">
                         View Our Project Sponsors
@@ -98,10 +99,12 @@
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='certifyingorganisation/list/';">
                 <h3>Certification</h3>
+                <hr />
                 {% if organisations %}
                     <h4 class="text-muted">
                     Certifying Organisations
                     </h4>
+                    <hr />
                     <div class="content-list">
                     {% for organisation in organisations %}
                         <h5>{{ organisation.name }}</h5>
@@ -120,6 +123,7 @@
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
                 <h3>Release Changelogs</h3>
+                <hr />
                 {% if versions %}
                 <h4 class="text-muted">
                     New Features and Releases
@@ -146,6 +150,7 @@
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='committees/';">
                 <h3>Project Teams</h3>
+                <hr />
                 {% if committees %}
                     <h4 class="text-muted">
                     Collaborate and Decide
@@ -172,10 +177,11 @@
     #action_text {
         font-size: 8px;
         font-weight: bold;
-        padding: 3px;
+        padding: 4px;
+        /*float: right;*/
     }
     h6 {
-        float: center;
+
     }
     </style>
     <script>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -117,6 +117,14 @@
                             <h5><strong><span>{{ team.name }}</span></strong></h5>
                         {% endfor %}
                     </div>
+                    {% else %}
+                    {% if user.is_staff or user == project.owner %}
+                        <h5>No teams are defined, but you can <a
+                                class="btn btn-default btn-mini"
+                                href='#'>create one</a></h5>
+                                
+                    {% endif %}
+
                 {% endif %}
             </div>
         </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -89,7 +89,7 @@
                 {% if user.is_staff or user == project.owner %}
                     <h6>No sponsors are defined, but you can <a
                     class="btn btn-default btn-mini" id="action_text"
-                    href='#'>create one</a></h6>
+                    href='{% url "sponsor-create" project.slug %}'>create one</a></h6>
                 {% endif %}
             {% endif %}
             </div>
@@ -108,7 +108,7 @@
                     {% if user.is_staff or user == project.owner %}
                         <h6>No certifying organisation are defined, but you can <a
                                 class="btn btn-default btn-mini" id="action_text"
-                                href='#'>register one</a></h6>
+                                href='{% url "certifyingorganisation-create" project.slug %}'>register one</a></h6>
                     {% endif %}
                 {% endif %}
             </div>
@@ -150,7 +150,7 @@
                     {% if user.is_staff or user == project.owner %}
                         <h5>No teams are defined, but you can <a
                                 class="btn btn-default btn-mini" id="action_text"
-                                href='#'>create one</a></h5>
+                                href='{% url "committee-create" project.slug %}'>create one</a></h5>
                     {% endif %}
                 {% endif %}
             </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -34,6 +34,17 @@
                     {% endif %}
                     {% if project.description %}
                         <p><i>{{ project.description }}</i></p>
+                    {% else %}
+                        {% if user.is_staff or user.project.owner %}
+                            <h3>No project description defined, but you can
+                                <a href="{% url 'project-update' project.slug %}"
+                                   class="btn btn-default btn-mini btn-edit"
+                                   data-placement="top" data-title="Update {{ project.name }}">
+                                  <span class="glyphicon glyphicon-pencil"></span>
+                                  add one
+                                </a>
+                            </h3>
+                        {% endif %}
                     {% endif %}
                 </div>
             </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -74,6 +74,12 @@
                     {% endif %}
                 {% endfor %}
                 </div>
+            {% else %}
+                {% if user.is_staff or user == project.owner %}
+                    <h6>No sponsors are defined, but you can <a
+                    class="btn btn-default btn-mini" id="action_text"
+                    href='#'>create one</a></h6>
+                {% endif %}
             {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='certifyingorganisation/list/';">
@@ -87,12 +93,12 @@
                         <h5>{{ organisation.name }}</h5>
                     {% endfor %}
                     </div>
-                    {% else %}
-                        {% if user.is_staff or user == project.owner %}
-                            <h5>No teams are defined, but you can <a
-                                    class="btn btn-default btn-mini"
-                                    href='#'>create one</a></h5>
-                        {% endif %}
+                {% else %}
+                    {% if user.is_staff or user == project.owner %}
+                        <h6>No certifying organisation are defined, but you can <a
+                                class="btn btn-default btn-mini" id="action_text"
+                                href='#'>register one</a></h6>
+                    {% endif %}
                 {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='version/list/';">
@@ -110,6 +116,12 @@
                         {% endif %}
                     {% endfor %}
                     </div>
+                {% else %}
+                    {% if user.is_staff or user == project.owner %}
+                        <h6>No versions are defined, but you can <a
+                        class="btn btn-default btn-mini" id="action_text"
+                        href='#'>create one</a></h6>
+                    {% endif %}
                 {% endif %}
             </div>
             <div class="panel panel-default custom-panel clickable-panel" onclick="window.location='committees/';">
@@ -120,20 +132,27 @@
                   </h4>
                     <div class="content-list">
                         {% for team in committees %}
-                            <h5><strong><span>{{ team.name }}</span></strong></h5>
+                            <h6><strong><span>{{ team.name }}</span></strong></h6>
                         {% endfor %}
                     </div>
                     {% else %}
                     {% if user.is_staff or user == project.owner %}
                         <h5>No teams are defined, but you can <a
-                                class="btn btn-default btn-mini"
+                                class="btn btn-default btn-mini" id="action_text"
                                 href='#'>create one</a></h5>
                     {% endif %}
                 {% endif %}
             </div>
         </div>
     </div>
-
+    <style>
+    #action_text {
+        font-size: 8px;
+        font-weight: bold;
+        padding: 3px;
+        float: right;
+    }
+    </style>
     <script>
         var slideIndex = 1;
         {% if screenshots %}

--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -22,7 +22,7 @@
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
             Certifying Organisations
-            {% if user.is_authenticated %}
+            {% if user.is_staff or user.project.owner %}
                 <div class="pull-right btn-group">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "certifyingorganisation-create" project_slug %}'

--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -17,7 +17,7 @@
             background-color: #F9F9F9;
         }
     </style>
-    
+
     <div class="page-header">
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
@@ -52,9 +52,11 @@
         {% if unapproved %}
             <h3>All certifying organisation are approved.</h3>
         {% else %}
+            {% if user.is_staff or user.project.owner %}
             <h3>No certifying organisation are defined, but you can <a
                     class="btn btn-default btn-mini"
                     href='{% url "certifyingorganisation-create" project_slug %}'>register one</a>.</h3>
+            {% endif %}
         {% endif %}
     {% endifequal %}
 

--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -52,11 +52,7 @@
         {% if unapproved %}
             <h3>All certifying organisation are approved.</h3>
         {% else %}
-            {% if user.is_staff or user.project.owner %}
-            <h3>No certifying organisation are defined, but you can <a
-                    class="btn btn-default btn-mini"
-                    href='{% url "certifyingorganisation-create" project_slug %}'>register one</a>.</h3>
-            {% endif %}
+            <h3>No certifying organisation are defined.</h3>
         {% endif %}
     {% endifequal %}
 

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -66,13 +66,7 @@
         {% if unapproved %}
             <h3>All sponsors are approved.</h3>
         {% else %}
-            {% if user.is_staff or user.project.owner %}
-                <h3>No sponsors are defined, but you can <a
-                        class="btn btn-default btn-mini"
-                        href='{% url "sponsor-create" project_slug %}'>create one</a>.</h3>
-            {% else %}
-                <h3>No sponsors are defined</h3>
-            {% endif %}
+            <h3>No sponsors are defined.</h3>
         {% endif %}
     {% endifequal %}
 

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -25,11 +25,13 @@
             {% if unapproved %}Unapproved {% endif %}Sponsors
                 <div class="pull-right btn-group">
                 {% if user.is_authenticated %}
-                    <a class="btn btn-default btn-mini tooltip-toggle icon"
-                       href='{% url "sponsor-create" project_slug %}'
-                       data-title="Create New Sponsor">
-                        {% show_button_icon "add" %}
-                    </a>
+                    {% if user.is_staff or user.project.owner %}
+                        <a class="btn btn-default btn-mini tooltip-toggle icon"
+                           href='{% url "sponsor-create" project_slug %}'
+                           data-title="Create New Sponsor">
+                            {% show_button_icon "add" %}
+                        </a>
+                    {% endif %}
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle icon"
                            href='{% url "pending-sponsor-list" project_slug %}'
@@ -64,7 +66,7 @@
         {% if unapproved %}
             <h3>All sponsors are approved.</h3>
         {% else %}
-            {% if user.is_staff %}
+            {% if user.is_staff or user.project.owner %}
                 <h3>No sponsors are defined, but you can <a
                         class="btn btn-default btn-mini"
                         href='{% url "sponsor-create" project_slug %}'>create one</a>.</h3>

--- a/django_project/changes/templates/sponsor/pending-list.html
+++ b/django_project/changes/templates/sponsor/pending-list.html
@@ -16,12 +16,14 @@
             {% if unapproved %}Unapproved {% endif %}
             Sponsors
             {% if user.is_authenticated %}
-                <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "sponsor-create" project_slug %}'
-                       data-title="Create New Sponsor">
-                        {% show_button_icon "add" %}</a>
-
+                    {% if user.is_staff or user.project.owner %}
+                        <div class="pull-right btn-group">
+                            <a class="btn btn-default btn-mini tooltip-toggle"
+                               href='{% url "sponsor-create" project_slug %}'
+                               data-title="Create New Sponsor">
+                                {% show_button_icon "add" %}
+                            </a>
+                    {% endif %}
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsor-list" project_slug %}'

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -15,13 +15,15 @@
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
             Sponsorship Levels
-           {% if user.is_staff %}
-                <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "sponsorshiplevel-create" project_slug %}'
-                       data-title="Create New Sponsorship Level">
-                        {% show_button_icon "add" %}</a>
-
+           {% if user.is_authenticated %}
+                       {% if user.is_staff or user.project.owner %}
+                            <div class="pull-right btn-group">
+                                <a class="btn btn-default btn-mini tooltip-toggle"
+                                   href='{% url "sponsorshiplevel-create" project_slug %}'
+                                   data-title="Create New Sponsorship Level">
+                                    {% show_button_icon "add" %}
+                                </a>
+                        {% endif%}
                         {% if not unapproved %}
                             <a class="btn btn-default btn-mini tooltip-toggle"
                                href='{% url "pending-sponsorshiplevel-list" project_slug %}'

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -16,11 +16,14 @@
             {% if unapproved %}Unapproved {% endif %}
             Sponsorship Periods
             {% if user.is_authenticated %}
-                <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "sponsorshipperiod-create" project_slug %}'
-                       data-title="Create New sponsorship period">
-                        <span class="glyphicon glyphicon-asterisk"></span></a>
+                    {% if user.is_staff or user.project.owner %}
+                        <div class="pull-right btn-group">
+                            <a class="btn btn-default btn-mini tooltip-toggle"
+                               href='{% url "sponsorshipperiod-create" project_slug %}'
+                               data-title="Create New sponsorship period">
+                                <span class="glyphicon glyphicon-asterisk"></span>
+                            </a>
+                    {% endif %}
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsorshipperiod-list" project_slug %}'

--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -45,11 +45,7 @@
         {% if unapproved %}
             <h3>All versions are approved.</h3>
         {% else %}
-            {% if user.is_staff or user.project.owner %}
-                <h3>No versions are defined, but you can <a
-                        class="btn btn-default btn-mini"
-                        href='{% url "version-create" project_slug %}'>create one</a>.</h3>
-            {% endif %}
+            <h3>No versions are defined.</h3>
         {% endif %}
     {%  endifequal %}
     {% for version in versions %}

--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -18,11 +18,13 @@
             Versions
             <div class="pull-right btn-group">
                 {% if user.is_authenticated and versions %}
-                    <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "version-create" versions.0.project.slug %}'
-                       data-title="Create New Version">
-                        {% show_button_icon "add" %}
-                    </a>
+                    {% if user.is_staff or user.project.owner %}
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                           href='{% url "version-create" versions.0.project.slug %}'
+                           data-title="Create New Version">
+                            {% show_button_icon "add" %}
+                        </a>
+                    {% endif %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "pending-version-list" versions.0.project.slug %}'
                        data-title="View Pending Versions">
@@ -43,9 +45,11 @@
         {% if unapproved %}
             <h3>All versions are approved.</h3>
         {% else %}
-            <h3>No versions are defined, but you can <a
-                    class="btn btn-default btn-mini"
-                    href='{% url "version-create" project_slug %}'>create one</a>.</h3>
+            {% if user.is_staff or user.project.owner %}
+                <h3>No versions are defined, but you can <a
+                        class="btn btn-default btn-mini"
+                        href='{% url "version-create" project_slug %}'>create one</a>.</h3>
+            {% endif %}
         {% endif %}
     {%  endifequal %}
     {% for version in versions %}

--- a/django_project/vota/templates/committee/list.html
+++ b/django_project/vota/templates/committee/list.html
@@ -29,10 +29,7 @@
         {% if unapproved %}
             <h3>All teams are approved.</h3>
         {% else %}
-            {% if user.is_staff or user == project.owner %}
-                <h3>No teams are defined, but you can <a
-                        class="btn btn-default btn-mini"
-                        href='{% url "committee-create" project_slug %}'>create one</a></h3>                    {% endif %}
+            <h3>No teams are defined.</h3>
         {% endif %}
     {%  endifequal %}
     {% for committee in committees %}

--- a/django_project/vota/templates/committee/list.html
+++ b/django_project/vota/templates/committee/list.html
@@ -29,9 +29,10 @@
         {% if unapproved %}
             <h3>All teams are approved.</h3>
         {% else %}
-            <h3>No teams are defined, but you can <a
-                    class="btn btn-default btn-mini"
-                    href='{% url "committee-create" project_slug %}'>create one</a></h3>
+            {% if user.is_staff or user == project.owner %}
+                <h3>No teams are defined, but you can <a
+                        class="btn btn-default btn-mini"
+                        href='{% url "committee-create" project_slug %}'>create one</a></h3>                    {% endif %}
         {% endif %}
     {%  endifequal %}
     {% for committee in committees %}


### PR DESCRIPTION
Fix  #580 

- [x] Teams
- [x] Certification
- [x] Sponsors
- [x] Release Changelogs
- [x] Add call to action for staff user or project owner inside of the content blocks in the project landing page:
- [x] action button within content block.
- [x] add call to action on empty project description only visible to staff user and project owner.

![screenshot from 2017-12-13 20 53 16](https://user-images.githubusercontent.com/10270148/33956687-ffd897d8-e047-11e7-8116-28fd2cc7add6.png)

- [x] action call working on button click.