### PR TITLE
make block contents clickable.

### DIFF
--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -84,7 +84,9 @@
                     </h4>
                     <div class="content-list">
                     {% for organisation in organisations %}
+                    <a href="#">
                         <h5>{{ organisation.name }}</h5>
+                    </a>
                     {% endfor %}
                     </div>
                 {% endif %}
@@ -119,7 +121,12 @@
                   </h4>
                     <div class="content-list">
                         {% for team in committees %}
-                            <h5><strong><span>{{ team.name }}</span></strong></h5>
+                            <h5>
+                                <span><a href="#">
+                                    {{ team.name }}
+                                </a>
+                                </span>
+                            </h5>
                         {% endfor %}
                     </div>
                 {% endif %}

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -68,9 +68,11 @@
                         {% ifchanged sponsor.sponsorship_level %}
                            <h4><img src="{% thumbnail sponsor.sponsorship_level.logo 20x20 %}"> {{ sponsor.sponsorship_level.name }}</h4>
                         {% endifchanged %}
-                            <img class="img-rounded tooltip-toggle"
+                            <a href="{% url 'sponsor-detail' project_slug=sponsor.project.slug slug=sponsor.slug %}">
+                                <img class="img-rounded tooltip-toggle"
                                  src="{% thumbnail sponsor.sponsor.logo 50x50 %}"
                                  data-title="{{ sponsor.sponsor.name }}">
+                             </a>
                     {% endif %}
                 {% endfor %}
                 </div>

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -84,7 +84,7 @@
                     </h4>
                     <div class="content-list">
                     {% for organisation in organisations %}
-                    <a href="#">
+                    <a href="{% url 'certifyingorganisation-detail' project_slug=organisation.project.slug slug=organisation.slug %}">
                         <h5>{{ organisation.name }}</h5>
                     </a>
                     {% endfor %}
@@ -103,9 +103,9 @@
                         <p><span class="text-muted">Version:</span>
                             <span class="pull-right">
                                 <a href="{% url 'version-detail' project_slug=version.project.slug slug=version.slug %}">
-                                    {{ version.name }}
-                                </a>
-                        </span></p>
+                                    {{ version.name }}</a>
+                            </span>
+                        </p>
                         {% else %}
                         <p><span class="text-muted">Version:</span> <span class="pull-right"><span>{{ version.name }}</span><span class="text-muted"> (pending)</span></span></p>
                         {% endif %}
@@ -122,9 +122,10 @@
                     <div class="content-list">
                         {% for team in committees %}
                             <h5>
-                                <span><a href="#">
-                                    {{ team.name }}
-                                </a>
+                                <span>
+                                    <a href="{% url 'committee-detail' project_slug=team.project.slug slug=team.slug %}">
+                                        {{ team.name }}
+                                    </a>
                                 </span>
                             </h5>
                         {% endfor %}

--- a/django_project/base/templates/project/new_detail.html
+++ b/django_project/base/templates/project/new_detail.html
@@ -98,7 +98,12 @@
                     <div class="version-list">
                     {% for version in versions %}
                         {% if version.approved %}
-                        <p><span class="text-muted">Version:</span> <span class="pull-right">{{ version.name }}</span></p>
+                        <p><span class="text-muted">Version:</span>
+                            <span class="pull-right">
+                                <a href="{% url 'version-detail' project_slug=version.project.slug slug=version.slug %}">
+                                    {{ version.name }}
+                                </a>
+                        </span></p>
                         {% else %}
                         <p><span class="text-muted">Version:</span> <span class="pull-right"><span>{{ version.name }}</span><span class="text-muted"> (pending)</span></span></p>
                         {% endif %}


### PR DESCRIPTION
Fix #644 
Make content block items clickable.

- [x] Sponsers
- [x] Certification 
- [x] Release Changelogs (version number)
- [x] Teams

![clickables-iloveimg-compressed](https://user-images.githubusercontent.com/10270148/33939587-69e55a64-e014-11e7-86ad-1e696abb660c.gif)