### PR TITLE
Pin version of hashed file storage to 1.0 because 2.0 gives an encodi…

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -16,7 +16,7 @@ django-widget-tweaks==1.3
 raven==5.8.1
 django-sentry==1.13.5
 requests==1.2.3
-django-hashedfilenamestorage
+django-hashedfilenamestorage==1.0
 # pypandoc is an interface for pandoc converter
 pypandoc==0.6.0
 beautifulsoup4==4.3.2


### PR DESCRIPTION
…ng error on some tests