### PR TITLE
make travis muted for collectstatic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - cd django_project
   - python manage.py makemigrations
   - python manage.py migrate
-  - python manage.py collectstatic --noinput
+  - python manage.py collectstatic --noinput --verbosity 0
   - coverage run manage.py test
 
 after_success:


### PR DESCRIPTION
Waiting for this patch: https://code.djangoproject.com/ticket/28973

Meanwhile, this is dividing our logs per 2! (3000 lines before, 1300 with this PR), much much better to scroll down and check why travis is failing.