### PR TITLE
add a dummy shift in DB to avoid Integrity Error

### DIFF
--- a/django_project/lesson/views/question.py
+++ b/django_project/lesson/views/question.py
@@ -354,9 +354,12 @@ class QuestionOrderSubmitView(
         try:
             questions_request = json.loads(specifications_json)
         except ValueError:
-            raise Http404(
-                'Error json values'
-            )
+            raise Http404('Error json values')
+
+        # Add dummy shift in the DB to avoid Integrity about unique_together
+        for question in questions:
+            question.question_number += len(questions_request)
+            question.save()
 
         for question_request in questions_request:
             question = questions.get(pk=question_request['id'])

--- a/django_project/lesson/views/section.py
+++ b/django_project/lesson/views/section.py
@@ -388,9 +388,12 @@ class SectionOrderSubmitView(LoginRequiredMixin, SectionMixin, UpdateView):
         try:
             sections_request = json.loads(sections_json)
         except ValueError:
-            raise Http404(
-                'Error json values'
-            )
+            raise Http404('Error json values')
+
+        # Add dummy shift in the DB to avoid Integrity about unique_together
+        for section in sections:
+            section.section_number += len(sections_request)
+            section.save()
 
         for section_request in sections_request:
             section = sections.get(id=section_request['id'])

--- a/django_project/lesson/views/specification.py
+++ b/django_project/lesson/views/specification.py
@@ -354,9 +354,12 @@ class SpecificationOrderSubmitView(
         try:
             specifications_request = json.loads(specifications_json)
         except ValueError:
-            raise Http404(
-                'Error json values'
-            )
+            raise Http404('Error json values')
+
+        # Add dummy shift in the DB to avoid Integrity about unique_together
+        for specification in specifications:
+            specification.specification_number += len(specifications_request)
+            specification.save()
 
         for specification_request in specifications_request:
             specification = specifications.get(id=specification_request['id'])


### PR DESCRIPTION
Ah, it seems the DB got me! Since my commit to add some constraints on the order number, the ordering is not working anymore.

If we could update the DB in a transaction (without integrity constraints), everything would be good because the JSON from the ajax request is correct according the DB. But because the `save` is done separately on each record in the DB, it's failing.  I checked the Django doc but I'm not sure we can disable integrity constraints by doing a bulk update command.

As we won't have a big lesson with thoussand of worksheets, I think it's fine to do this small dummy temporary shift in the DB. What do you think @timlinux ? Or should I disable my work on `unique_together`.