### PR TITLE
add permissions on lesson app, review mixin

### DIFF
--- a/django_project/base/forms.py
+++ b/django_project/base/forms.py
@@ -73,6 +73,15 @@ class ProjectForm(forms.ModelForm):
             'moderation queue.')
     )
 
+    lesson_manager = forms.ModelMultipleChoiceField(
+        queryset=User.objects.order_by('username'),
+        widget=CustomSelectMultipleWidget("user", is_stacked=False),
+        required=False,
+        help_text=_(
+            'Managers of the lesson app in this project. '
+            'They will be allowed to create or remove lessons.')
+    )
+
     # noinspection PyClassicStyleClass
     class Meta:
         """Meta class."""
@@ -89,6 +98,7 @@ class ProjectForm(forms.ModelForm):
             'signature',
             'changelog_manager',
             'sponsorship_manager',
+            'lesson_manager',
             'certification_manager',
             'credit_cost',
             'certificate_credit',
@@ -112,6 +122,7 @@ class ProjectForm(forms.ModelForm):
                 Field('signature', css_class="form-control"),
                 Field('changelog_manager', css_class="form-control"),
                 Field('sponsorship_manager', css_class="form-control"),
+                Field('lesson_manager', css_class="form-control"),
                 Field('certification_manager', css_class="form-control"),
                 Field('credit_cost', css_class="form-control"),
                 Field('certificate_credit', css_class="form-control"),
@@ -127,6 +138,8 @@ class ProjectForm(forms.ModelForm):
         self.fields['sponsorship_manager'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         self.fields['certification_manager'].label_from_instance = \
+            lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
+        self.fields['lesson_manager'].label_from_instance = \
             lambda obj: "%s <%s>" % (obj.get_full_name(), obj)
         # self.helper.add_input(Submit('submit', 'Submit'))
 

--- a/django_project/base/migrations/0015_project_lesson_manager.py
+++ b/django_project/base/migrations/0015_project_lesson_manager.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('base', '0014_project_accent_color'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='lesson_manager',
+            field=models.ManyToManyField(help_text='Managers of the lesson app in this project. They will be allowed to create or remove lessons.', related_name='lesson_manager', null=True, to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+    ]

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -188,6 +188,16 @@ class Project(models.Model):
             'moderation queue.')
     )
 
+    lesson_manager = models.ManyToManyField(
+        User,
+        related_name='lesson_manager',
+        blank=True,
+        null=True,
+        help_text=_(
+            'Managers of the lesson app in this project. '
+            'They will be allowed to create or remove lessons.')
+    )
+
     certification_manager = models.ManyToManyField(
         User,
         related_name='certification_manager',

--- a/django_project/changes/views/category.py
+++ b/django_project/changes/views/category.py
@@ -183,7 +183,7 @@ class CategoryListView(CategoryMixin, StaffuserRequiredMixin, ListView):
             return queryset
 
 
-class CategoryOrderView(CategoryMixin, StaffuserRequiredMixin, ListView):
+class CategoryOrderView(StaffuserRequiredMixin, CategoryMixin, ListView):
     """List view to order category"""
     context_object_name = 'categories'
     template_name = 'category/order.html'

--- a/django_project/lesson/templates/section/includes/row-worksheet.html
+++ b/django_project/lesson/templates/section/includes/row-worksheet.html
@@ -9,14 +9,14 @@
     </div>
 
     <div class="col-lg-3">
-        {% if user.is_staff or user == project.owner %}
+        {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
             <div class="btn-group pull-right">
-                <a class="btn btn-default btn-mini"
+                <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Delete {{ section.name }}"
                    href='{% url "worksheet-delete" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}'>
                     <span class="glyphicon glyphicon-minus"></span>
                 </a>
-                <a class="btn btn-default btn-mini"
+                <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Update {{ section.name }}"
                    href='{% url "worksheet-update" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.id %}'>
                     <span class="glyphicon glyphicon-pencil"></span>

--- a/django_project/lesson/templates/section/includes/section-list-detail.html
+++ b/django_project/lesson/templates/section/includes/section-list-detail.html
@@ -9,7 +9,7 @@
     </div>
 
     <div class="col-lg-3">
-        {% if user.is_staff or user == project.owner %}
+        {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
             <div class="btn-group pull-right">
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    href='{% url "worksheet-create" project.slug section.slug %}'
@@ -21,12 +21,12 @@
                    data-title="Worksheet Order">
                     <span class="glyphicon glyphicon-sort-by-order"></span>
                 </a>
-                <a class="btn btn-default btn-mini"
+                <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Delete {{ section.name }}"
                    href='{% url "section-delete" project_slug=section.project.slug slug=section.slug %}'>
                     <span class="glyphicon glyphicon-minus"></span>
                 </a>
-                <a class="btn btn-default btn-mini"
+                <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Update {{ section.name }}"
                    href='{% url "section-update" project_slug=section.project.slug slug=section.slug %}'>
                     <span class="glyphicon glyphicon-pencil"></span>

--- a/django_project/lesson/templates/section/list.html
+++ b/django_project/lesson/templates/section/list.html
@@ -20,7 +20,7 @@
         <h1 class="text-muted">
             {{ project.name }} Worksheet Sections
             <div class="pull-right btn-group">
-                {% if user.is_staff or user == project.owner %}
+                {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "section-create" project_slug=project.slug %}'
                        data-title="Create New Section">

--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -27,7 +27,7 @@
                         data-title="Back">
                         <span class="glyphicon glyphicon-arrow-left"></span>
                     </a>
-                    {% if user.is_staff or user == project.owner %}
+                    {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                         <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
                            href='{% url "worksheet-delete" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}'
                            data-title="Delete {{ worksheet.module }}">
@@ -83,7 +83,7 @@
             <p>{{ worksheet.exercise_task | base_markdown }}</p>
         </div>
         <div style="margin-bottom: 20px" class="details-worksheet col-lg-5 requirement-table">
-            {% if user.is_staff or user == project.owner %}
+            {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                 <div class="pull-right btn-group requirement-action" style="margin-bottom:5px;display:none;">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "specification-create" worksheet.section.project.slug worksheet.section.slug worksheet.slug %}'
@@ -103,12 +103,15 @@
                         <tr style="background-color:#d6e6fb;">
                             <th style="padding:5px;">Name</th>
                             <th style="padding:5px;">Expectation</th>
+                         {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                             <th class="requirement-action" style="text-align:right;padding-right:0px;display:none;background-color:#FFFFFF">Actions</th>
+                         {% endif %}
                         </tr>
                         {% for requirement in requirements %}
                             <tr>
                                 <td style="background-color:#f3f9fe;padding:5px;">{{ requirement.title }}</td>
                                 <td style="padding:5px;">{{ requirement.value }}</td>
+                                {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                                 <td style="padding-right: 0">
                                     <div class="btn-group pull-right requirement-action" style="display:none;">
                                         <a class="btn btn-default btn-mini tooltip-toggle"
@@ -123,6 +126,7 @@
                                         </a>
                                     </div>
                                 </td>
+                                {% endif %}
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -172,7 +176,7 @@
           <h3 class="custom-heading" style="margin-left:-40px"><strong>Check your knowledge:</strong></h3>
         </div>
         <div class="col-lg-3 pull-right">
-            {% if user.is_staff or user == project.owner %}
+            {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                 <div class="pull-right btn-group question-answer-action" style="display:none;">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                   href='{% url "question-create" worksheet.section.project.slug worksheet.section.slug worksheet.slug %}'
@@ -199,7 +203,7 @@
                               <strong>{{ question.question }}:</strong>
                             </div>
                             <div class="col-lg-2">
-                                {% if user.is_staff or user == project.owner %}
+                                {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                                     <div class="pull-right btn-group question-answer-action" style="display:none;">
                                         <a class="btn btn-default btn-mini tooltip-toggle"
                                       href='{% url "answer-create" worksheet.section.project.slug worksheet.section.slug worksheet.slug question.pk %}'
@@ -224,7 +228,7 @@
                     <ol type="a">
                         {% for answer in answers %}
                             <li style="margin-bottom: 10px">
-                                {% if user.is_staff or user == project.owner %}
+                                {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                                     {# We insert a tick for the correct answer and if the user is allowed and we display explanations. #}
                                     {% if answer.is_correct %}
                                         <span class="question-answer-action" style="display:none;">&#10004;</span>
@@ -267,7 +271,7 @@
           <h3 class="custom-heading" style="margin-left:-40px"><strong>Further reading: </strong></h3>
         </div>
         <div class="col-lg-3 pull-right">
-            {% if user.is_staff or user == project.owner %}
+            {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                 <div class="pull-right btn-group further-reading-action" style="display:none;">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "further-reading-create" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug worksheet_slug=worksheet.slug %}'
@@ -288,7 +292,7 @@
                         {% if info.link %}
                             <a target="_blank" href="{{ info.link }}">{{ info.link }}</a>
                         {% endif %}
-                        {% if user.is_staff or user == project.owner %}
+                        {% if user in project.lesson_manager.all or user.is_staff or user == project.owner %}
                             <div class="pull-right btn-group">
                                 <a class="btn btn-default btn-mini btn-delete tooltip-toggle further-reading-action" style="display:none;"
                                    href='{% url "further-reading-delete" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug worksheet_slug=worksheet.slug pk=info.pk%}'

--- a/django_project/lesson/views/question.py
+++ b/django_project/lesson/views/question.py
@@ -250,7 +250,7 @@ class QuestionUpdateView(
 
 
 class QuestionOrderView(
-    QuestionMixin, StaffuserRequiredMixin, ListView):
+    StaffuserRequiredMixin, QuestionMixin, ListView):
     """List view to order questions"""
     context_object_name = 'questions'
     template_name = 'question/order.html'

--- a/django_project/lesson/views/section.py
+++ b/django_project/lesson/views/section.py
@@ -302,7 +302,7 @@ class SectionUpdateView(
                 'ERROR: Section by this name is already exists!')
 
 
-class SectionOrderView(SectionMixin, StaffuserRequiredMixin, ListView):
+class SectionOrderView(StaffuserRequiredMixin, SectionMixin, ListView):
     """List view to order section"""
     context_object_name = 'sections'
     template_name = 'section/order.html'

--- a/django_project/lesson/views/specification.py
+++ b/django_project/lesson/views/specification.py
@@ -250,7 +250,7 @@ class SpecificationUpdateView(
 
 
 class SpecificationOrderView(
-    SpecificationMixin, StaffuserRequiredMixin, ListView):
+    StaffuserRequiredMixin, SpecificationMixin, ListView):
     """List view to order specifications"""
     context_object_name = 'specifications'
     template_name = 'specification/order.html'

--- a/django_project/lesson/views/worksheet.py
+++ b/django_project/lesson/views/worksheet.py
@@ -252,7 +252,7 @@ class WorksheetDeleteView(
         return qs
 
 
-class WorksheetOrderView(WorksheetMixin, StaffuserRequiredMixin, ListView):
+class WorksheetOrderView(StaffuserRequiredMixin, WorksheetMixin, ListView):
     """List view to order worksheet."""
     context_object_name = 'worksheet'
     template_name = 'worksheet/order.html'


### PR DESCRIPTION
I think a few things to check on Projecta how permissions are done.
I tried a non-admin account on changelog.qgis.org, I can see icons to remove. But then I can't get the webpage. It's confusing to display it if we have a 302 error after.

Can you tell me also why the mixin `LoginRequiredMixin` is enough in this view? To remove a project, you shouldn't need only a login, you need a staff login for instance `StaffuserRequiredMixin` or to be the project owner.
https://github.com/kartoza/projecta/blob/develop/django_project/base/views/project.py#L166