### PR TITLE
fix permissions and add about link

### DIFF
--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -80,6 +80,13 @@
 {% endblock %}
 
 {% block content %}
+    <style>
+        .about-link:hover {
+            color: darkblue !important;
+            text-decoration: none !important;
+        }
+    </style>
+
     <div class="row">
         <div class="col-lg-10">
             <h1>{{ certifyingorganisation.name }}</h1><br/>
@@ -89,10 +96,11 @@
         <div class="col-lg-2">
 
             <div class="pull-right">
-            <span class="glyphicon glyphicon-info-sign tooltip-toggle"
-                  style="font-size: 14pt; padding: 7px; color: #D3D3D3; display: inline-block; vertical-align: middle"
-                  data-title="Hover to the container to see action buttons">
-            </span>
+            <a class="glyphicon glyphicon-info-sign tooltip-toggle about-link"
+               style="font-size: 14pt; padding: 7px; color: #D3D3D3; display: inline-block; vertical-align: middle"
+               data-title="About Certification"
+               href="{% url 'about' certifyingorganisation.project.slug %}"
+            ></a>
 
 
             <div class="btn-group">

--- a/django_project/certification/templates/certifying_organisation/list.html
+++ b/django_project/certification/templates/certifying_organisation/list.html
@@ -22,7 +22,7 @@
         <h1 class="text-muted">
             {% if unapproved %}Unapproved {% endif %}
             Certifying Organisations
-            {% if user.is_staff or user.project.owner %}
+            {% if user.is_staff or user == the_project.owner or user in the_project.certification_manager.all %}
                 <div class="pull-right btn-group">
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        href='{% url "certifyingorganisation-create" project_slug %}'

--- a/django_project/changes/templates/category/list.html
+++ b/django_project/changes/templates/category/list.html
@@ -36,7 +36,7 @@
                             <span class="glyphicon glyphicon-th-list"></span>
                         </a>
                     {% endif %}
-                    {% if user.is_staff %}
+                    {% if user.is_staff or user in the_project.changelog_manager.all or user == the_project.owner %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                             href='{% url "category-order" project_slug %}'
                             data-title="Order Categories">
@@ -75,11 +75,13 @@
             </div>
             <div class="col-lg-2">
                 <div class="btn-group pull-right">
-                    {%  if not category.approved and user.is_staff %}
-                        <a class="btn btn-default btn-mini"
-                           href='{% url "category-approve" project_slug=category.project.slug slug=category.slug %}'>
-                            <span class="glyphicon glyphicon-thumbs-up"></span>
-                        </a>
+                    {%  if not category.approved %}
+                        {% if user.is_staff or user in the_project.changelog_manager.all or user == the_project.owner %}
+                            <a class="btn btn-default btn-mini"
+                               href='{% url "category-approve" project_slug=category.project.slug slug=category.slug %}'>
+                                <span class="glyphicon glyphicon-thumbs-up"></span>
+                            </a>
+                        {% endif %}
                     {% endif %}
                     <a class="btn btn-default btn-mini"
                        href='{% url "category-delete" project_slug=category.project.slug slug=category.slug %}'>

--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -18,7 +18,7 @@
             Versions
             <div class="pull-right btn-group">
                 {% if user.is_authenticated and versions %}
-                    {% if user.is_staff or user == versions.0.project.owner or user in versions.0.project.changelog_manager.all %}
+                    {% if user.is_staff or user == the_project.owner or user in the_project.changelog_manager.all %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "version-create" versions.0.project.slug %}'
                            data-title="Create New Version">
@@ -26,7 +26,7 @@
                         </a>
                     {% endif %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
-                       href='{% url "pending-version-list" versions.0.project.slug %}'
+                       href='{% url "pending-version-list" the_project.slug %}'
                        data-title="View Pending Versions">
                         <span class="glyphicon glyphicon-time"></span>
                     </a>

--- a/django_project/changes/templates/version/list.html
+++ b/django_project/changes/templates/version/list.html
@@ -18,7 +18,7 @@
             Versions
             <div class="pull-right btn-group">
                 {% if user.is_authenticated and versions %}
-                    {% if user.is_staff or user.project.owner %}
+                    {% if user.is_staff or user == versions.0.project.owner or user in versions.0.project.changelog_manager.all %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "version-create" versions.0.project.slug %}'
                            data-title="Create New Version">

--- a/django_project/changes/views/category.py
+++ b/django_project/changes/views/category.py
@@ -20,7 +20,7 @@ from django.http import HttpResponseRedirect, Http404
 from django.db import IntegrityError
 from django.db.models import Q
 from django.core.exceptions import ValidationError
-from braces.views import LoginRequiredMixin, StaffuserRequiredMixin
+from braces.views import LoginRequiredMixin
 from ..models import Category, Version
 from ..forms import CategoryForm
 

--- a/django_project/changes/views/category.py
+++ b/django_project/changes/views/category.py
@@ -128,7 +128,7 @@ class JSONCategoryListView(CategoryMixin, JSONResponseMixin, ListView):
         return qs
 
 
-class CategoryListView(CategoryMixin, LoginRequiredMixin, ListView):
+class CategoryListView(LoginRequiredMixin, CategoryMixin, ListView):
     """List view for Category."""
     context_object_name = 'categories'
     template_name = 'category/list.html'
@@ -610,7 +610,7 @@ class PendingCategoryListView(
         return self.queryset
 
 
-class ApproveCategoryView(CategoryMixin, LoginRequiredMixin, RedirectView):
+class ApproveCategoryView(LoginRequiredMixin, CategoryMixin, RedirectView):
     """Redirect view for approving Category."""
     permanent = False
     query_string = True

--- a/django_project/changes/views/category.py
+++ b/django_project/changes/views/category.py
@@ -242,7 +242,7 @@ class CategoryOrderView(LoginRequiredMixin, CategoryMixin, ListView):
             return queryset
 
 
-class CategoryDetailView(LoginRequiredMixin, CategoryMixin, DetailView):
+class CategoryDetailView(CategoryMixin, DetailView):
     """Detail view for Category."""
     context_object_name = 'category'
     template_name = 'category/detail.html'
@@ -510,14 +510,14 @@ class CategoryUpdateView(LoginRequiredMixin, CategoryMixin, UpdateView):
         projects which user created (staff gets all projects)
         :rtype: QuerySet
         """
-        self.project_slug = self.kwargs.get('project_slug', None)
-        self.project = Project.objects.get(slug=self.project_slug)
+        project_slug = self.kwargs.get('project_slug', None)
+        project = Project.objects.get(slug=project_slug)
         qs = Category.approved_objects
         if self.request.user.is_staff:
             return qs
         else:
             return qs.filter(
-                Q(project=self.project) &
+                Q(project=project) &
                 (Q(project__owner=self.request.user) |
                  Q(project__changelog_manager=self.request.user)))
 

--- a/django_project/changes/views/sponsor.py
+++ b/django_project/changes/views/sponsor.py
@@ -573,7 +573,7 @@ class PendingSponsorListView(LoginRequiredMixin, SponsorMixin,
         return self.queryset
 
 
-class ApproveSponsorView(SponsorMixin, LoginRequiredMixin, RedirectView):
+class ApproveSponsorView(LoginRequiredMixin, SponsorMixin, RedirectView):
     """Redirect view for approving Sponsor."""
     permanent = False
     query_string = True
@@ -668,7 +668,7 @@ def generate_sponsor_cloud(request, **kwargs):
             'the_project': project})
 
 
-class GenerateSponsorPDFView(SponsorMixin, LoginRequiredMixin, TemplateView):
+class GenerateSponsorPDFView(LoginRequiredMixin, SponsorMixin, TemplateView):
     """Template View for invoice generation"""
     context_object_name = 'sponsors'
     template_name = 'sponsor/invoice.html'

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -371,16 +371,16 @@ class VersionDeleteView(LoginRequiredMixin, VersionMixin, DeleteView):
         :rtype: QuerySet
         :raises: Http404
         """
-        self.project_slug = self.kwargs.get('project_slug', None)
-        self.project = Project.objects.get(slug=self.project_slug)
+        project_slug = self.kwargs.get('project_slug', None)
+        project = Project.objects.get(slug=project_slug)
         if not self.request.user.is_authenticated():
             raise Http404
-        qs = Version.objects.filter(project=self.project)
+        qs = Version.objects.filter(project=project)
         if self.request.user.is_staff:
             return qs
         else:
             return qs.filter(
-                Q(project=self.project) &
+                Q(project=project) &
                 (Q(author=self.request.user) |
                  Q(project__owner=self.request.user) |
                  Q(project__changelog_manager=self.request.user)))
@@ -470,14 +470,14 @@ class VersionUpdateView(LoginRequiredMixin, VersionMixin, UpdateView):
         :returns: A queryset which is filtered to only show approved Versions.
         :rtype: QuerySet
         """
-        self.project_slug = self.kwargs.get('project_slug', None)
-        self.project = Project.objects.get(slug=self.project_slug)
+        project_slug = self.kwargs.get('project_slug', None)
+        project = Project.objects.get(slug=project_slug)
         versions_qs = Version.objects.all()
         if self.request.user.is_staff:
             versions_qs = versions_qs
         else:
             versions_qs = versions_qs.filter(
-                Q(project=self.project) &
+                Q(project=project) &
                 (Q(author=self.request.user) |
                  Q(project__owner=self.request.user) |
                  Q(project__changelog_manager=self.request.user)))


### PR DESCRIPTION
fix #689 

This PR:
- [x] Fixed permissions for changelog manager to create, update and delete versions and category
- [x] Added about link in certifying organisation page
- [x] Also fixed permissions for certification manager to see action buttons in certifying organisation list

changelog managers can see create button and should be able to create, update and delete versions
![screenshot from 2018-01-30 14-51-51](https://user-images.githubusercontent.com/26101337/35554423-3a38dcc0-05ce-11e8-8081-f11d0d275fd3.png)


add clickable about link
![screenshot from 2018-01-30 14-52-04](https://user-images.githubusercontent.com/26101337/35554367-0d0c1546-05ce-11e8-89d8-a11e3b6b4dd8.png)
