### PR TITLE
remove warnings in migration

### DIFF
--- a/django_project/base/migrations/0016_auto_20180201_1642.py
+++ b/django_project/base/migrations/0016_auto_20180201_1642.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0015_project_lesson_manager'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='project',
+            name='certification_manager',
+            field=models.ManyToManyField(help_text='Managers of the certification app in this project. They will receive email notification about organisation and have the same permissions as project owner in the certification app.', related_name='certification_manager', to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='changelog_manager',
+            field=models.ManyToManyField(help_text='Managers of the changelog in this project. They will be allowed to approve changelog entries in the moderation queue.', related_name='changelog_manager', to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='lesson_manager',
+            field=models.ManyToManyField(help_text='Managers of the lesson app in this project. They will be allowed to create or remove lessons.', related_name='lesson_manager', to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='project',
+            name='sponsorship_manager',
+            field=models.ManyToManyField(help_text='Managers of the sponsorship in this project. They will be allowed to approve sponsor entries in the moderation queue.', related_name='sponsorship_manager', to=settings.AUTH_USER_MODEL, blank=True),
+        ),
+    ]

--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -170,7 +170,7 @@ class Project(models.Model):
         User,
         related_name='changelog_manager',
         blank=True,
-        null=True,
+        # null=True, null has no effect on ManyToManyField.
         help_text=_(
             'Managers of the changelog in this project. '
             'They will be allowed to approve changelog entries in the '
@@ -181,7 +181,7 @@ class Project(models.Model):
         User,
         related_name='sponsorship_manager',
         blank=True,
-        null=True,
+        # null=True, null has no effect on ManyToManyField.
         help_text=_(
             'Managers of the sponsorship in this project. '
             'They will be allowed to approve sponsor entries in the '
@@ -192,7 +192,7 @@ class Project(models.Model):
         User,
         related_name='lesson_manager',
         blank=True,
-        null=True,
+        # null=True, null has no effect on ManyToManyField.
         help_text=_(
             'Managers of the lesson app in this project. '
             'They will be allowed to create or remove lessons.')
@@ -202,7 +202,7 @@ class Project(models.Model):
         User,
         related_name='certification_manager',
         blank=True,
-        null=True,
+        # null=True, null has no effect on ManyToManyField.
         help_text=_(
             'Managers of the certification app in this project. '
             'They will receive email notification about organisation and have'


### PR DESCRIPTION
Before:
```
WARNINGS:
base.Project.certification_manager: (fields.W340) null has no effect on ManyToManyField.
base.Project.changelog_manager: (fields.W340) null has no effect on ManyToManyField.
base.Project.lesson_manager: (fields.W340) null has no effect on ManyToManyField.
base.Project.sponsorship_manager: (fields.W340) null has no effect on ManyToManyField.
```