### PR TITLE
re order entries within the same category

### DIFF
--- a/django_project/changes/migrations/0010_auto_20180205_1046.py
+++ b/django_project/changes/migrations/0010_auto_20180205_1046.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('changes', '0009_auto_20180116_1849'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='entry',
+            options={'ordering': ['version', 'category', 'sequence_number']},
+        ),
+        migrations.AddField(
+            model_name='entry',
+            name='sequence_number',
+            field=models.IntegerField(default=0, help_text='The order in which this entry is listed within the category.', verbose_name='Entry number'),
+        ),
+    ]

--- a/django_project/changes/templates/entry/order.html
+++ b/django_project/changes/templates/entry/order.html
@@ -1,0 +1,48 @@
+{% extends "project_base.html" %}
+{% load thumbnail %}
+
+{% block title %}Entries - {{ block.super }}{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+    <h1>Entries</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <div class="page-header">
+        <h1 class="text-muted">
+            <span class="glyphicon glyphicon-sort-by-order"></span> Order Entries for {{ category.name }}
+            <span id="order-saved" hidden class="alert alert-success" style="font-size: 9pt; padding: 3px;font-style: italic;">
+                order saved</span>
+            <span id="order-not-saved" hidden class="alert alert-danger" style="font-size: 9pt; padding: 3px;font-style: italic;">
+                order not saved</span>
+            <div class="pull-right btn-group" style="margin-top: 5px;">
+                <a class="btn btn-default btn-mini tooltip-toggle"
+                   href='{% url "version-detail" project_slug=version.project.slug slug=version.slug %}'
+                   data-title="Entry List">
+                    <span class="glyphicon glyphicon-th-list"></span>
+                </a>
+            </div>
+        </h1>
+    </div>
+    {% if entry.count == 0 %}
+        <h3>No entries are defined.</h3>
+    {% endif %}
+    <ul id="sortable" data-url="{% url "entry-submit-order" project_pk=version.project.pk version_pk=version.pk category_pk=category.pk %}">
+    {% for entry in object_list %}
+        <li class="row order" style="margin-top:6px;" id="{{ entry.id }}-{{ entry.title }}" >
+            <div class="col-lg-12">
+                <p>
+                    <span class="glyphicon glyphicon-menu-hamburger" style="margin-right: 20px"></span>
+                    {{ entry.title }}
+                </p>
+            </div>
+        </li>
+    {%  endfor %}
+    </ul>
+    <hr />
+
+{% endblock %}
+

--- a/django_project/changes/templates/version/detail-content.html
+++ b/django_project/changes/templates/version/detail-content.html
@@ -83,6 +83,15 @@
 
         {% for row in version.categories %}
             {% if row.entries %}
+                <div class="btn-group btn-group pull-right">
+                {% if user.is_staff or user in project.changelog_manager.all and not rst_download %}
+                    <a class="btn-circle btn-default btn-mini tooltip-toggle"
+                       data-title="Order Entries"
+                       href='{% url "entry-order" project_pk=version.project.pk version_pk=version.pk category_pk=row.category.pk %}'>
+                        <span class="glyphicon glyphicon-sort-by-order"></span>
+                    </a>
+                {% endif %}
+                </div>
                 <a class="anchor" id="category-{{ row.category.id }}"></a>
                 <h2 class="text-muted">
                     {{ row.category.name }}

--- a/django_project/changes/urls.py
+++ b/django_project/changes/urls.py
@@ -42,6 +42,9 @@ from views import (
     PendingEntryListView,
     AllPendingEntryList,
     ApproveEntryView,
+    EntryOrderView,
+    EntryOrderSubmitView,
+
     # Sponsor
     SponsorDetailView,
     SponsorDeleteView,
@@ -178,6 +181,14 @@ urlpatterns = patterns(
     url(regex='^entry/update/(?P<pk>\d+)$',
         view=EntryUpdateView.as_view(),
         name='entry-update'),
+    url(regex='^(?P<project_pk>[\w-]+)/version/(?P<version_pk>[\w.-]+)/'
+              'order/(?P<category_pk>[\w-]+)$',
+        view=EntryOrderView.as_view(),
+        name='entry-order'),
+    url(regex='^(?P<project_pk>[\w-]+)/version/(?P<version_pk>[\w.-]+)/'
+              'submit-order/(?P<category_pk>[\w-]+)$',
+        view=EntryOrderSubmitView.as_view(),
+        name='entry-submit-order'),
 
     # Feeds
     url(regex='^(?P<project_slug>[\w-]+)/rss/latest-version/$',


### PR DESCRIPTION
Ticket #30 

![order](https://user-images.githubusercontent.com/1609292/35799173-9c52e600-0a6d-11e8-8113-ad83447fc609.gif)

I can still refactor the code later to avoid the copy/paste of the HTML template.

@timlinux @ann26 I need to check why I need to remove this variable from the context. I'm not sure about this middleware:
If I don't introduce this hack, I get:
```
Traceback:
File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  157.                     response = middleware_method(request, response)
File "/home/web/django_project/core/custom_middleware.py" in process_template_response
  98.             context['the_version'] = context.get('entry').version

Exception Type: AttributeError at /en/1/version/35/order/1
Exception Value: 'QuerySet' object has no attribute 'version'
```

I have a list of entry L98, so it's normal that `version` doesn't work on a collection of objects.
https://github.com/kartoza/projecta/blob/develop/django_project/core/custom_middleware.py#L98