### PR TITLE
alter description length to be 1000 characters

### DIFF
--- a/django_project/certification/migrations/0015_auto_20180207_0531.py
+++ b/django_project/certification/migrations/0015_auto_20180207_0531.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0014_certifyingorganisation_url'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='coursetype',
+            name='description',
+            field=models.TextField(help_text='Course type description.', max_length=1000, null=True, blank=True),
+        ),
+    ]

--- a/django_project/certification/migrations/0015_auto_20180207_1243.py
+++ b/django_project/certification/migrations/0015_auto_20180207_1243.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='coursetype',
             name='description',
-            field=models.TextField(help_text='Course type description.', max_length=1000, null=True, blank=True),
+            field=models.TextField(help_text='Course type description - 1000 characters limit.', max_length=1000, null=True, blank=True),
         ),
     ]

--- a/django_project/certification/models/course_type.py
+++ b/django_project/certification/models/course_type.py
@@ -41,7 +41,7 @@ class CourseType(models.Model):
 
     description = models.TextField(
         help_text=_('Course type description.'),
-        max_length=250,
+        max_length=1000,
         null=True,
         blank=True,
     )

--- a/django_project/certification/models/course_type.py
+++ b/django_project/certification/models/course_type.py
@@ -40,7 +40,7 @@ class CourseType(models.Model):
     )
 
     description = models.TextField(
-        help_text=_('Course type description.'),
+        help_text=_('Course type description - 1000 characters limit.'),
         max_length=1000,
         null=True,
         blank=True,

--- a/django_project/certification/templates/course_type/detail.html
+++ b/django_project/certification/templates/course_type/detail.html
@@ -48,11 +48,11 @@
         </div>
     </div>
 
-    <div class="details" style="margin-top: 20px">
-        <span class="grey-italic col-lg-3">Course type</span><span class="col-lg-9">{{ coursetype.name }}<br/></span>
-        <span class="grey-italic col-lg-3">Description</span><span class="col-lg-9">{{ coursetype.description }}<br/></span>
-        <span class="grey-italic col-lg-3">Instruction hours</span><span class="col-lg-9">{{ coursetype.instruction_hours }}<br/></span>
-        <span class="grey-italic col-lg-3">Link</span><span class="col-lg-9">{{ coursetype.coursetype_link }}<br/></span>
+    <div class="details" style="margin-top: 20px; width: 100% !important">
+        <span class="grey-italic col-lg-2">Course type</span><span class="col-lg-10">{{ coursetype.name }}<br/></span>
+        <span class="grey-italic col-lg-2">Description</span><span class="col-lg-10">{{ coursetype.description }}<br/></span>
+        <span class="grey-italic col-lg-2">Instruction hours</span><span class="col-lg-10">{{ coursetype.instruction_hours }}<br/></span>
+        <span class="grey-italic col-lg-2">Link</span><span class="col-lg-10">{{ coursetype.coursetype_link }}<br/></span>
     </div>
 
     <script>


### PR DESCRIPTION
fix #669 

This PR:
- [x] Changed the descriptions length in course type to be 1000 characters (previously 250)
![screenshot from 2018-02-07 10-36-56](https://user-images.githubusercontent.com/26101337/35897321-3927af20-0bf3-11e8-954b-d802a726d569.png)
