### PR TITLE
fix duplicate queries

### DIFF
--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -680,7 +680,7 @@ class PendingCertifyingOrganisationListView(
                             (Q(project__owner=self.request.user) |
                              Q(organisation_owners=self.request.user) |
                              Q(project__certification_manager=self.request.user
-                               )))
+                               ))).distinct()
                 return queryset
             else:
                 raise Http404(


### PR DESCRIPTION
fix #763 

This PR fixes duplicate pending certifying organisation queries when a user has multiple role within a project.