### PR TITLE
add update and delete view

### DIFF
--- a/django_project/base/models/project.py
+++ b/django_project/base/models/project.py
@@ -73,7 +73,7 @@ def get_default_organisation():
     # default organisation can be changed in the live site.
 
     organisation = \
-        Organisation.objects.get_or_create(name='Kartoza', approved=True)[0]
+        Organisation.objects.get_or_create(name='Public', approved=True)[0]
     return organisation.pk
 
 

--- a/django_project/base/templates/custom_domain/delete.html
+++ b/django_project/base/templates/custom_domain/delete.html
@@ -1,0 +1,63 @@
+{% extends "project_base.html" %}
+{% load custom_markup %}
+
+{% block title %}Domain Deleted - {{ block.super }}{% endblock %}
+
+{% block extra_head %}
+{% endblock %}
+
+{% block page_title %}
+  <h1>Domain Deleted</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <style>
+        .btn-delete:hover {
+            background: #c12e2a;
+            color: white;
+            border-color: #c12e2a;
+        }
+        .btn-edit:hover {
+            background: darkblue;
+            color: white;
+            border-color: darkblue;
+        }
+    </style>
+
+  <form action="" id="delete-confirmation" method="post">{% csrf_token %}
+    <div class="alert row">
+      <div class="col-lg-10">
+        <p class="lead">Please confirm you wish to delete the domain below!</p>
+      </div>
+      <div class="col-lg-2">
+        <div class="btn-group pull-right">
+          <a class="btn btn-default btn-sm tooltip-toggle btn-delete"
+             href="#"
+             onClick="$('#delete-confirmation').submit()"
+             data-title="{{ domain.domain }}">
+            <span class="glyphicon glyphicon-minus"></span>
+          </a>
+          <a class="btn btn-default btn-sm btn-edit tooltip-toggle"
+             href='{% url "domain-list" %}'
+             data-title="Cancel">
+            <span class="glyphicon glyphicon-arrow-left"></span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-lg-12">
+        <h3><span class="text-muted">Domain:</span> {{ domain.domain }}</h3>
+      </div>
+    </div>
+    <div>
+        <p>User: {{ domain.user.first_name }} {{ domain.user.last_name }} ({{ domain.user.username }})</p>
+        {% if domain.project %}
+            <p>Project: {{ domain.project }}</p>
+        {% endif %}
+        {% if domain.organisation %}
+            <p>Organisation: {{ domain.organisation }}</p>
+        {% endif %}
+    </div>
+  </form>
+{% endblock %}

--- a/django_project/base/templates/custom_domain/list.html
+++ b/django_project/base/templates/custom_domain/list.html
@@ -19,26 +19,38 @@
             color: white;
             border-color: green;
         }
+
+        .btn-delete:hover {
+            background: #c12e2a;
+            color: white;
+            border-color: #c12e2a;
+        }
+
+        .btn-edit:hover {
+            background: darkblue;
+            color: white;
+            border-color: darkblue;
+        }
     </style>
 
     <div class="page-header">
         <h1 class="text-muted">
-            Organisations
+            Domains
             {% if user.is_authenticated %}
                 <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
+                    <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                        href='{% url "register-domain" %}'
                        data-title="Register New Domain">
                         {% show_button_icon "add" %}
                     </a>
                     {% if not unapproved %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
+                        <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                            href='{% url "domain-pending-list" %}'
                            data-title="View Pending Domains">
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% else %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
+                        <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                            href='{% url "domain-list" %}'
                            data-title="View Domains List">
                             <span class="glyphicon glyphicon-th-list"></span>
@@ -75,10 +87,20 @@
                     {%  if not domain.approved %}
                         <a class="btn btn-default btn-mini btn-approve"
                            href='{% url "domain-approve" domain.pk %}'
-                            data-title="Approve {{ organisation.name }}">
+                            data-title="Approve {{ domain.domain }}">
                             <span class="glyphicon glyphicon-thumbs-up"></span>
                         </a>
                     {% endif %}
+                    <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
+                       href='{% url "domain-delete" domain.pk %}'
+                        data-title="Delete {{ domain.domain }}">
+                        <span class="glyphicon glyphicon-minus"></span>
+                    </a>
+                    <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
+                       href='{% url "domain-update" domain.pk %}'
+                        data-title="Update {{ domain.domain }}">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </a>
                 </div>
             </div>
         {% endif %}

--- a/django_project/base/templates/custom_domain/update.html
+++ b/django_project/base/templates/custom_domain/update.html
@@ -1,0 +1,68 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Update Domain</h1>
+{% endblock page_title %}
+
+{% block content %}
+
+    <style>
+        .info-error {
+            color: darkred;
+        }
+    </style>
+
+    <section id="forms">
+        <div class='container'>
+            {% csrf_token %}
+            {% crispy form %}
+            {% for form in inlines %}
+                {% crispy form %}
+            {% endfor %}
+        </div>
+    </section>
+
+    <script>
+    $(document).ready(function () {
+        $('legend').html('Update Domain')
+
+        $('#div_id_project').append('<p class="info-error" id="project-error"></p>');
+        $('#div_id_organisation').append('<p class="info-error" id="organisation-error"></p>');
+
+        $('select[id=id_role]').change(function () {
+            $('.info-error').html('');
+            if($(this).val() == 'Project') {
+                $('#div_id_organisation').hide();
+                $('select[id=id_organisation]').val('');
+                $('#div_id_project').show();
+            }else {
+                $('select[id=id_project]').val('');
+                $('#div_id_project').hide();
+                $('#div_id_organisation').show();
+            }
+            }
+        );
+        $('select[id=id_role]').trigger('change');
+
+        $('form').submit(function () {
+            var project = $('select[id=id_project]').val();
+            var organisation = $('select[id=id_organisation]').val();
+            if(project === '' && organisation === ''){
+                if(project === ''){
+                    $('#project-error').html('This field should not be empty.');
+                }
+
+                if(organisation === ''){
+                    $('#organisation-error').html('This field should not be empty.');
+                }
+                return false
+            }else {
+                return true
+            }
+        })
+    });
+    </script>
+
+{% endblock %}

--- a/django_project/base/templates/organisation/delete.html
+++ b/django_project/base/templates/organisation/delete.html
@@ -1,13 +1,13 @@
 {% extends "project_base.html" %}
 {% load custom_markup %}
 
-{% block title %}Project Deleted - {{ block.super }}{% endblock %}
+{% block title %}Domain Deleted - {{ block.super }}{% endblock %}
 
 {% block extra_head %}
 {% endblock %}
 
 {% block page_title %}
-  <h1>Project Deleted</h1>
+  <h1>Domain Deleted</h1>
 {% endblock page_title %}
 
 {% block content %}
@@ -17,23 +17,29 @@
             color: white;
             border-color: #c12e2a;
         }
+
+        .btn-edit:hover {
+            background: darkblue;
+            color: white;
+            border-color: darkblue;
+        }
     </style>
 
   <form action="" id="delete-confirmation" method="post">{% csrf_token %}
     <div class="alert row">
       <div class="col-lg-10">
-        <p class="lead">Please confirm you wish to delete the project below!</p>
+        <p class="lead">Please confirm you wish to delete the domain below!</p>
       </div>
       <div class="col-lg-2">
-        <div class="btn-group">
+        <div class="btn-group pull-right">
           <a class="btn btn-default btn-delete btn-sm tooltip-toggle"
              href="#"
              onClick="$('#delete-confirmation').submit()"
-             data-title="{{ project.name }}">
+             data-title="{{ domain.domain }}">
             <span class="glyphicon glyphicon-minus"></span>
           </a>
-          <a class="btn btn-default btn-sm tooltip-toggle"
-             href='{% url "project-list" %}'
+          <a class="btn btn-default btn-sm btn-edit tooltip-toggle"
+             href='{% url "domain-list" %}'
              data-title="Cancel">
             <span class="glyphicon glyphicon-arrow-left"></span>
           </a>
@@ -42,19 +48,13 @@
     </div>
     <div class="row">
       <div class="col-lg-12">
-        <h3><span class="text-muted">Project:</span> {{ project.name }}</h3>
+        <h3><span class="text-muted">Organisation:</span> {{ organisation.name }}</h3>
       </div>
     </div>
-    <div class="row">
-      <div class="col-lg-8">
-        {{ project.description|base_markdown }}
-      </div>
-      <div class="col-lg-4">
-        {% if project.image_file %}
-          <img class="img-responsive img-rounded"
-               src="{{ MEDIA_URL }}{{ project.image_file }}" />
-        {%  endif %}
-      </div>
+    <div>
+        {% if organisation.owner %}
+            <p>Owner: {{ organisation.owner.first_name }} {{ organisation.owner.last_name }} ({{ organisation.owner.username }})</p>
+        {% endif %}
     </div>
   </form>
 {% endblock %}

--- a/django_project/base/templates/organisation/delete.html
+++ b/django_project/base/templates/organisation/delete.html
@@ -35,11 +35,11 @@
           <a class="btn btn-default btn-delete btn-sm tooltip-toggle"
              href="#"
              onClick="$('#delete-confirmation').submit()"
-             data-title="{{ domain.domain }}">
+             data-title="{{ organisation.name }}">
             <span class="glyphicon glyphicon-minus"></span>
           </a>
           <a class="btn btn-default btn-sm btn-edit tooltip-toggle"
-             href='{% url "domain-list" %}'
+             href='{% url "list-organisation" %}'
              data-title="Cancel">
             <span class="glyphicon glyphicon-arrow-left"></span>
           </a>

--- a/django_project/base/templates/organisation/list.html
+++ b/django_project/base/templates/organisation/list.html
@@ -72,7 +72,7 @@
         <li class="row order" style="list-style-type: none; margin-top:10px; margin-left: 10px; margin-right: 1px" id="{{ organisation.id }}-{{ organisation.name }}">
             <div class="col-lg-8">
                 <h4>{{ organisation.name }}
-                {% if organisation.name == 'Kartoza' %}
+                {% if organisation.name == 'Public' %}
                     <span class="text-muted" style="font-size: 16px"> &nbsp;&nbsp;(default)</span>
                 {% endif %}
                 {% if not organisation.approved %}

--- a/django_project/base/templates/organisation/list.html
+++ b/django_project/base/templates/organisation/list.html
@@ -19,6 +19,16 @@
             color: white;
             border-color: green;
         }
+        .btn-delete:hover {
+            background: #c12e2a;
+            color: white;
+            border-color: #c12e2a;
+        }
+        .btn-edit:hover {
+            background: darkblue;
+            color: white;
+            border-color: darkblue;
+        }
     </style>
 
     <div class="page-header">
@@ -26,19 +36,19 @@
             Organisations
             {% if user.is_authenticated %}
                 <div class="pull-right btn-group">
-                    <a class="btn btn-default btn-mini tooltip-toggle"
+                    <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                        href='{% url "create-organisation" %}'
                        data-title="Create New Organisation">
                         {% show_button_icon "add" %}
                     </a>
                     {% if not unapproved %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
+                        <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                            href='{% url "pending-list-organisation" %}'
                            data-title="View Pending Organisations">
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% else %}
-                        <a class="btn btn-default btn-mini tooltip-toggle"
+                        <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
                            href='{% url "list-organisation" %}'
                            data-title="View Organisations">
                             <span class="glyphicon glyphicon-th-list"></span>
@@ -82,6 +92,16 @@
                             <span class="glyphicon glyphicon-thumbs-up"></span>
                         </a>
                     {% endif %}
+                    <a class="btn btn-default btn-mini btn-delete tooltip-toggle"
+                       href='{% url "organisation-delete" organisation.pk %}'
+                        data-title="Delete {{ organisation.name }}">
+                        <span class="glyphicon glyphicon-minus"></span>
+                    </a>
+                    <a class="btn btn-default btn-mini btn-edit tooltip-toggle"
+                       href='{% url "organisation-update" organisation.pk %}'
+                        data-title="Update {{ organisation.name }}">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </a>
                 </div>
             </div>
         {% endif %}

--- a/django_project/base/templates/organisation/update.html
+++ b/django_project/base/templates/organisation/update.html
@@ -1,0 +1,27 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Update Organisation</h1>
+{% endblock page_title %}
+
+{% block content %}
+
+    <section id="forms">
+        <div class='container'>
+            {% csrf_token %}
+            {% crispy form %}
+            {% for form in inlines %}
+                {% crispy form %}
+            {% endfor %}
+        </div>
+    </section>
+
+    <script>
+    $(document).ready(function () {
+        $('legend').html('Update Organisation')
+    });
+    </script>
+
+{% endblock %}

--- a/django_project/base/urls.py
+++ b/django_project/base/urls.py
@@ -66,7 +66,7 @@ urlpatterns = patterns(
     url(regex='^domain/(?P<pk>[\w-]+)/delete/$',
         view=DomainDeleteView.as_view(),
         name='domain-delete'),
-    url(regex='^project/(?P<pk>[\w-]+)/update/$',
+    url(regex='^domain/(?P<pk>[\w-]+)/update/$',
         view=DomainUpdateView.as_view(),
         name='domain-update'),
 

--- a/django_project/base/urls.py
+++ b/django_project/base/urls.py
@@ -26,11 +26,15 @@ from views import (
     DomainListView,
     PendingDomainListView,
     ApproveDomainView,
+    DomainDeleteView,
+    DomainUpdateView,
 
     CreateOrganisationView,
     OrganisationListView,
     ApproveOrganisationView,
     PendingOrganisationListView,
+    OrganisationDeleteView,
+    OrganisationUpdateView,
 )
 
 urlpatterns = patterns(
@@ -59,6 +63,12 @@ urlpatterns = patterns(
     url(regex='^domain-approve/(?P<pk>[\w-]+)/$',
         view=ApproveDomainView.as_view(),
         name='domain-approve'),
+    url(regex='^domain/(?P<pk>[\w-]+)/delete/$',
+        view=DomainDeleteView.as_view(),
+        name='domain-delete'),
+    url(regex='^project/(?P<pk>[\w-]+)/update/$',
+        view=DomainUpdateView.as_view(),
+        name='domain-update'),
 
     # Organisation management
     url(regex='^create-organisation/$',
@@ -73,6 +83,12 @@ urlpatterns = patterns(
     url(regex='^approve-organisation/(?P<pk>[\w-]+)/$',
         view=ApproveOrganisationView.as_view(),
         name='approve-organisation'),
+    url(regex='^organisation/(?P<pk>[\w-]+)/delete/$',
+        view=OrganisationDeleteView.as_view(),
+        name='organisation-delete'),
+    url(regex='^organisation/(?P<pk>[\w-]+)/update/$',
+        view=OrganisationUpdateView.as_view(),
+        name='organisation-update'),
 
     # Project management
     url(regex='^pending-project/list/$',

--- a/django_project/base/views/organisation.py
+++ b/django_project/base/views/organisation.py
@@ -190,7 +190,8 @@ class OrganisationUpdateView(
             return qs.filter(owner=self.request.user)
 
     def get_context_data(self, **kwargs):
-        context = super(OrganisationUpdateView, self).get_context_data(**kwargs)
+        context = super(
+            OrganisationUpdateView, self).get_context_data(**kwargs)
         return context
 
     def get_success_url(self):

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -41,6 +41,7 @@
             </ul>
         </li>
     </ul>
+    {% if user.is_staff %}
     <ul class="nav navbar-nav">
         <li>
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
@@ -62,6 +63,7 @@
             </ul>
         </li>
     </ul>
+    {% endif %}
     <ul class="nav navbar-nav">
         <li>
             <a href="{% url 'project-create' %}">Create Project</a>


### PR DESCRIPTION
Partially fix #663 

This PR (number is based upon lists in #663):
- [x] 1. Added delete view for organisation and domain.
- [x] 2. Only site admins can see domain menu.
- [x] 3. Setup custom domain button on the project detail page is only available to its owner.
- [x] 6. Login in custom domain is working. Log in page redirects to the same domain as where the login request was made.
- [x] 7. Added edit view for organisation and domain.
- [x] 9. Changed the default organisation name from Kartoza to ‘Public'.


Static & Gifs

- Delete view for organisation
![peek 2018-02-20 06-32](https://user-images.githubusercontent.com/26101337/36401161-216426e2-1608-11e8-96ed-25c399390dc2.gif)

- Delete view for custom domain
![peek 2018-02-20 06-33](https://user-images.githubusercontent.com/26101337/36401167-2fde281c-1608-11e8-9f80-265e51f7abbb.gif)

- Domain menu navigation view
for staff users:
![screenshot from 2018-02-20 06-23-39](https://user-images.githubusercontent.com/26101337/36400960-c3e2cbb4-1606-11e8-80db-559a368a918c.png)

for non staff users:
![screenshot from 2018-02-20 06-23-19](https://user-images.githubusercontent.com/26101337/36400963-d16bfed6-1606-11e8-904c-d5d854fef4b5.png)

- Login on custom domain:
![peek 2018-02-20 06-36](https://user-images.githubusercontent.com/26101337/36401220-8da8efae-1608-11e8-9df3-d45271c98f4b.gif)

- Edit view for organisations:
![peek 2018-02-20 06-54](https://user-images.githubusercontent.com/26101337/36401623-1ba6a7cc-160b-11e8-9129-b7c97dcbc85a.gif)

- Edit view for custom domain:
![peek 2018-02-20 06-54-2](https://user-images.githubusercontent.com/26101337/36401629-289e5b0a-160b-11e8-804b-9d0c695e246c.gif)

- Default organisation is "Public"
![screenshot from 2018-02-20 06-56-56](https://user-images.githubusercontent.com/26101337/36401655-53d3c210-160b-11e8-856e-b673ff42fdec.png)
