### PR TITLE
use the `url` property instead of doing URL concatenation for media

### DIFF
--- a/django_project/base/templates/project/delete.html
+++ b/django_project/base/templates/project/delete.html
@@ -44,7 +44,7 @@
       <div class="col-lg-4">
         {% if project.image_file %}
           <img class="img-responsive img-rounded"
-               src="{{ MEDIA_URL }}{{ project.image_file }}" />
+               src="{{ project.image_file.url }}" />
         {%  endif %}
       </div>
     </div>

--- a/django_project/changes/templates/category/delete.html
+++ b/django_project/changes/templates/category/delete.html
@@ -44,7 +44,7 @@
             <div class="col-lg-4">
                 {% if category.image_file %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ category.image_file }}" />
+                         src="{{ category.image_file.url }}" />
                 {%  endif %}
             </div>
         </div>

--- a/django_project/changes/templates/category/detail.html
+++ b/django_project/changes/templates/category/detail.html
@@ -42,7 +42,7 @@
         <div class="col-lg-4">
             {% if category.image_file %}
                 <img class="img-responsive img-rounded pull-right"
-                     src="{{ MEDIA_URL }}{{ category.image_file }}" />
+                     src="{{ category.image_file.url }}" />
             {%  endif %}
         </div>
     </div>

--- a/django_project/changes/templates/category/order.html
+++ b/django_project/changes/templates/category/order.html
@@ -35,7 +35,7 @@
         <li class="row order" style="margin-top:6px;" id="{{ category.id }}-{{ category.name }}" >
             <div class="col-lg-1" style="padding-top: 10px;">
                 {% if category.image_file %}
-                    <a href="{{ MEDIA_URL }}{{ category.image_file }}">
+                    <a href="{{ category.image_file.url }}">
                         <img class="img-responsive img-rounded pull-right"
                              src="{% thumbnail category.image_file 50x50 crop %}" />
                     </a>

--- a/django_project/changes/templates/entry/delete.html
+++ b/django_project/changes/templates/entry/delete.html
@@ -44,7 +44,7 @@
             <div class="col-lg-4">
                 {% if entry.image_file %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ entry.image_file }}" />
+                         src="{{ entry.image_file.url }}" />
                 {%  endif %}
             </div>
         </div>

--- a/django_project/changes/templates/entry/includes/entry_detail.html
+++ b/django_project/changes/templates/entry/includes/entry_detail.html
@@ -45,22 +45,22 @@
             {% if entry.image_file %}
                 {% if entry.image_file|is_gif %}
                     {% if not rst_download %}
-                        <img id="{{ MEDIA_URL }}{{ entry.image_file }}" class="img-responsive img-rounded pull-right"
-                             data-gifffer="{{ MEDIA_URL }}{{ entry.image_file }}"
+                        <img id="{{ entry.image_file.url }}" class="img-responsive img-rounded pull-right"
+                             data-gifffer="{{ entry.image_file.url }}"
                              gifffer-alt=""/>{# see core/settings/contrib.py for large-entry #}
                         <a href="#" class="pop-gif">
                             Click here for bigger size animation.
                         </a>
                     {% else %}
-                        <a href="{{ MEDIA_URL }}{{ entry.image_file }}">
+                        <a href="{{ entry.image_file.url }}">
                         <img class="img-responsive img-rounded pull-right"
-                             src="{{ MEDIA_URL }}{{ entry.image_file }}"
+                             src="{{ entry.image_file.url }}"
                              alt=""/>{# see core/settings/contrib.py for large-entry #}
                         </a>
                     {% endif %}
                 {% else %}
                     <a href="#" class="pop-image">
-                    <img id="{{ MEDIA_URL }}{{ entry.image_file }}" class="img-responsive img-rounded pull-right"
+                    <img id="{{ entry.image_file.url }}" class="img-responsive img-rounded pull-right"
                          src="{{ entry.image_file|thumbnail_url:'large-entry' }}"
                          alt=""/>{# see core/settings/contrib.py for large-entry #}
                     </a>

--- a/django_project/changes/templates/sponsor/delete.html
+++ b/django_project/changes/templates/sponsor/delete.html
@@ -44,7 +44,7 @@
             <div class="col-lg-4">
                 {% if sponsor.logo %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ sponsor.logo }}" />
+                         src="{{ sponsor.logo.url }}" />
                 {%  endif %}
             </div>
         </div>

--- a/django_project/changes/templates/sponsor/detail.html
+++ b/django_project/changes/templates/sponsor/detail.html
@@ -40,12 +40,12 @@
 
             {% if sponsor.sponsor.logo %}
                 <img class="img-responsive img-rounded pull-left" style="max-height: 75px"
-                     src="{{ MEDIA_URL }}{{ sponsor.sponsor.logo }}" />
+                     src="{{ sponsor.sponsor.logo.url }}" />
             {% endif %}
 
             {% if sponsor.sponsorship_level.logo %}
                 <img class="img-responsive img-rounded pull-right"
-                     src="{{ MEDIA_URL }}{{ sponsor.sponsorship_level.logo }}" width="60"/>
+                     src="{{ sponsor.sponsorship_level.logo.url }}" width="60"/>
             {% endif %}
         </div>
     </div>
@@ -124,7 +124,7 @@
                             Sponsor agreement
                         </div>
                         <div>
-                            <b><a href="{{ MEDIA_URL }}{{ sponsor.agreement }}"> Document agreement</a></b>
+                            <b><a href="{{ sponsor.agreement.url }}"> Document agreement</a></b>
                         </div>
                     </p>
                 {% endif %}

--- a/django_project/changes/templates/sponsor/invoice.html
+++ b/django_project/changes/templates/sponsor/invoice.html
@@ -52,7 +52,7 @@
                     <tr style="padding-bottom: 25px;">
                         <td colspan="1" style="vertical-align:top">
                             {% if project.image_file %}
-                                <img src="{{ MEDIA_URL }}{{ project.image_file }}" />
+                                <img src="{{ project.image_file.url }}" />
                             {% endif %}
                         </td>
                         <td colspan="2" style="vertical-align:top">

--- a/django_project/changes/templates/sponsor/list.html
+++ b/django_project/changes/templates/sponsor/list.html
@@ -89,7 +89,7 @@
                                      src="{% thumbnail sponsor.sponsor.logo 50x50 crop %}"/>
                             </a>
                             {% else %}
-                                <a href="{{ MEDIA_URL }}{{ sponsor.sponsor.logo }}">
+                                <a href="{{ sponsor.sponsor.logo.url }}">
                                     <img class="img-responsive img-rounded pull-right"
                                          src="{% thumbnail sponsor.sponsor.logo 50x50 crop %}"/>
                                 </a>
@@ -136,7 +136,7 @@
             <div class="row" style="margin-top:10px;">
                     <div class="col-lg-1">
                         {% if sponsor.sponsor.logo %}
-                            <a href="{{ MEDIA_URL }}{{ sponsor.sponsor.logo }}">
+                            <a href="{{ sponsor.sponsor.logo.url }}">
                                 <img class="img-responsive img-rounded pull-right"
                                      src="{% thumbnail sponsor.sponsor.logo 50x50 crop %}"/>
                             </a>

--- a/django_project/changes/templates/sponsor/pending-list.html
+++ b/django_project/changes/templates/sponsor/pending-list.html
@@ -50,7 +50,7 @@
         <div class="row" style="margin-top:10px;">
             <div class="col-lg-1">
                 {% if sponsor.logo %}
-                    <a href="{{ MEDIA_URL }}{{ sponsor.logo }}">
+                    <a href="{{ sponsor.logo.url }}">
                         <img class="img-responsive img-rounded pull-right"
                              src="{% thumbnail sponsor.logo 50x50 crop %}"/>
                     </a>

--- a/django_project/changes/templates/sponsor/sponsor_cloud.html
+++ b/django_project/changes/templates/sponsor/sponsor_cloud.html
@@ -19,7 +19,7 @@
 
     <div style="margin: 30px auto; text-align: center">
     {% if image != 'none' %}
-        <img style="border: 2px solid #F5F5F5" src="{{ MEDIA_URL }}{{ image }}">
+        <img style="border: 2px solid #F5F5F5" src="{{ image.url }}">
     {% else %}
         <h3>No current sponsor found</h3>
     {% endif %}

--- a/django_project/changes/templates/sponsorship_level/delete.html
+++ b/django_project/changes/templates/sponsorship_level/delete.html
@@ -41,7 +41,7 @@
       <div class="col-lg-4">
         {% if sponsorshiplevel.logo %}
           <img class="img-responsive img-rounded"
-               src="{{ MEDIA_URL }}{{ sponsorshiplevel.logo }}" />
+               src="{{ sponsorshiplevel.logo.url }}" />
         {%  endif %}
       </div>
     </div>

--- a/django_project/changes/templates/sponsorship_level/detail.html
+++ b/django_project/changes/templates/sponsorship_level/detail.html
@@ -43,7 +43,7 @@
     <div class="col-lg-4">
       {% if sponsorshiplevel.logo %}
         <img class="img-responsive img-rounded pull-right"
-             src="{{ MEDIA_URL }}{{ sponsorshiplevel.logo }}" />
+             src="{{ sponsorshiplevel.logo.url }}" />
       {%  endif %}
     </div>
   </div>

--- a/django_project/changes/templates/sponsorship_level/list.html
+++ b/django_project/changes/templates/sponsorship_level/list.html
@@ -50,7 +50,7 @@
         <div class="row" style="margin-top:10px;">
             <div class="col-lg-1">
                 {% if sponsorshiplevel.logo %}
-                    <a href="{{ MEDIA_URL }}{{ sponsorshiplevel.logo }}">
+                    <a href="{{ sponsorshiplevel.logo.url }}">
                         <img class="img-responsive img-rounded pull-right"
                              src="{% thumbnail sponsorshiplevel.logo 50x50 crop %}"/>
                     </a>

--- a/django_project/changes/templates/sponsorship_period/detail.html
+++ b/django_project/changes/templates/sponsorship_period/detail.html
@@ -44,13 +44,13 @@
             {% endifnotequal %}
         {% if sponsorshipperiod.sponsorshiplevel.logo %}
         <img class="img-responsive img-rounded"
-             src="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsorshiplevel.logo }}" width="100" />
+             src="{{ sponsorshipperiod.sponsorshiplevel.logo.url }}" width="100" />
       {%  endif %}
     </div>
   <div class="col-lg-4">
       {% if sponsorshipperiod.sponsor.logo %}
         <img class="img-responsive img-rounded pull-right"
-             src="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}" />
+             src="{{ sponsorshipperiod.sponsor.logo.url }}" />
       {%  endif %}
     </div>
   </div>

--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -66,7 +66,7 @@
                 <tr>
                     <td>
                         {% if sponsorshipperiod.sponsor.logo %}
-                            <a href="{{ MEDIA_URL }}{{ sponsorshipperiod.sponsor.logo }}">
+                            <a href="{{ sponsorshipperiod.sponsor.logo.url }}">
                                 <img class="img-responsive"
                                      src="{% thumbnail sponsorshipperiod.sponsor.logo 30x30 %}"/>
                             </a>

--- a/django_project/changes/templates/version/delete.html
+++ b/django_project/changes/templates/version/delete.html
@@ -44,7 +44,7 @@
             <div class="col-lg-4">
                 {% if version.image_file %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ version.image_file }}" />
+                         src="{{ version.image_file.url }}" />
                 {%  endif %}
             </div>
         </div>

--- a/django_project/changes/templates/version/detail-content.html
+++ b/django_project/changes/templates/version/detail-content.html
@@ -56,7 +56,7 @@
     <div class="row">
         <div class="col-lg-12">
             {% if not rst_download %}
-                <a href="{{ MEDIA_URL }}{{ version.image_file }}">
+                <a href="{{ version.image_file.url }}">
                     <img class="img-responsive img-rounded center-block"
                          src="{{ version.image_file.url }}"/>
                 </a>

--- a/django_project/changes/templates/version/detail-thumbs.html
+++ b/django_project/changes/templates/version/detail-thumbs.html
@@ -34,7 +34,7 @@
     <div class="row">
         {% if version.project.image_file %}
             <div class="col-lg-3">
-                <a href="{{ MEDIA_URL }}{{ version.project.image_file }}">
+                <a href="{{ version.project.image_file.url }}">
                     <img class="img-responsive img-rounded pull-left"
                          src="{{ version.project.image_file|thumbnail_url:'medium-entry' }}"/>
                 </a>
@@ -82,7 +82,7 @@
         <div class="col-md-3 thumbnail-to-wrap">
             <div class="thumbnail">
                 {% if entry.image_file %}
-                    <a href="{{ MEDIA_URL }}{{ entry.image_file }}">
+                    <a href="{{ entry.image_file.url }}">
                         <img class="img-responsive img-rounded"
                              src="{{ entry.image_file|thumbnail_url:'thumb300x200' }}" alt=""/>
                     </a>

--- a/django_project/changes/templates/version/includes/version-list-detail.html
+++ b/django_project/changes/templates/version/includes/version-list-detail.html
@@ -4,7 +4,7 @@
     <div class="col-lg-1">
         {% if version.image_file %}
             <a class="pull-left"
-               href="{{ MEDIA_URL }}{{ version.image_file }}">
+               href="{{ version.image_file.url }}">
                 <img class="img-responsive img-rounded"
                      src="{% thumbnail version.image_file 150x90 crop %}" />
             </a>

--- a/django_project/lesson/templates/question/delete.html
+++ b/django_project/lesson/templates/question/delete.html
@@ -36,7 +36,7 @@
             <div class="col-lg-12">
                 <h3><span class="text-muted">Question:</span> {{ question.question }}</h3>
                 {% if question.question_image %}
-                    <img src="{{ MEDIA_URL }}{{ question.question_image }}"/>
+                    <img src="{{ question.question_image.url }}"/>
                 {% endif %}
             </div>
         </div>

--- a/django_project/vota/templates/ballot/delete.html
+++ b/django_project/vota/templates/ballot/delete.html
@@ -44,7 +44,7 @@
             <div class="col-lg-4">
                 {% if ballot.image_file %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ ballot.image_file }}" />
+                         src="{{ ballot.image_file.url }}" />
                 {%  endif %}
             </div>
         </div>

--- a/django_project/vota/templates/committee/delete.html
+++ b/django_project/vota/templates/committee/delete.html
@@ -46,7 +46,7 @@
             <div class="col-lg-4">
                 {% if committee.image_file %}
                     <img class="img-responsive img-rounded"
-                         src="{{ MEDIA_URL }}{{ committee.image_file }}" />
+                         src="{{ committee.image_file.url }}" />
                 {%  endif %}
             </div>
         </div>


### PR DESCRIPTION
In Pycharm, search and replace with regex:
From `\{\{ MEDIA_URL \}\}\{\{ (.*) \}\}` to `{{ $1.url }}`

I find this code better than a URL concatenation. I guess django is doing the URL smartly.

Following this blogpost http://staticfiles.productiondjango.com/blog/stop-using-static-url-in-templates/