### PR TITLE
Allow only certifying organisation managers to access 'call to action'

### DIFF
--- a/django_project/certification/templates/certifying_organisation/detail.html
+++ b/django_project/certification/templates/certifying_organisation/detail.html
@@ -336,8 +336,7 @@
     <th style="margin-top: 0;">
         <h2 class="custom-heading">Training Centers</h2>
     </th>
-
-        {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
+        {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
         <td>
             <div class="button1 button-action" style="display: none; margin-top: -30px; margin-bottom: 20px;">
             <div class="btn-group pull-right">
@@ -406,7 +405,7 @@
         </th>
 
         <td>
-        {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
+        {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
         <div class="button1 button-action" style="display: none; margin-top: -30px; margin-bottom: 20px;">
             <div class="btn-group pull-right">
             <a class="btn btn-default btn-sm tooltip-toggle"
@@ -471,7 +470,7 @@
         <h2 class="custom-heading">Course Conveners</h2>
     </th>
     <td>
-        {% if user in certifyingorganisation.organisation_owners.all or user.is_staff or user == project.owner or user in certifyingorganisation.project.certification_manager.all %}
+        {% if user.is_staff or user == the_project.owner or user in the_project.certification_managers.all %}
         <div class="button1 button-action" style="display: none; margin-top: -30px; margin-bottom: 20px">
             <div class="btn-group pull-right">
             <a class="btn btn-default btn-sm tooltip-toggle"


### PR DESCRIPTION
Fix #678 
Allow only certying organisation managers to access call to action

# non loged in user and non certying organisation managers will not see call to action as shown below.

![call-to-action](https://user-images.githubusercontent.com/10270148/36424447-f9ced962-164b-11e8-9745-9f84b7fef538.png)
