### PR TITLE
fix redirection when not enough permissions to view a page

### DIFF
--- a/django_project/changes/views/entry.py
+++ b/django_project/changes/views/entry.py
@@ -6,7 +6,7 @@ from base.models import Project
 import logging
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.views.generic import (
     ListView,
     CreateView,
@@ -292,6 +292,13 @@ class PendingEntryListView(
     context_object_name = 'unapproved_entries'
     template_name = 'entry/pending-list.html'
     paginate_by = 1000
+
+    def no_permissions_fail(self, request=None):
+        """Redirection if not enough permissions to view the page."""
+        return redirect(reverse('version-detail', kwargs={
+            'project_slug': self.kwargs.get('project_slug', None),
+            'slug': self.kwargs.get('version_slug', None),
+        }))
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.

--- a/django_project/core/settings/prod.py
+++ b/django_project/core/settings/prod.py
@@ -5,7 +5,10 @@
 from os.path import exists, dirname, join
 
 from .project import *  # noqa
-from .secret import SENTRY_KEY
+try:
+    from .secret import SENTRY_KEY
+except ImportError:
+    SENTRY_KEY = None
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts


### PR DESCRIPTION
After adding/updating an entry in the changelog, a normal user will be redirected to the pending queue. We should add this method to redirect users when they don't have enough permissions to see the view.