### PR TITLE
Add support for tables in markdown using extensions

### DIFF
--- a/django_project/base/templatetags/custom_markup.py
+++ b/django_project/base/templatetags/custom_markup.py
@@ -11,7 +11,7 @@ register = template.Library()
 @register.filter(name='base_markdown', is_safe=True)
 @stringfilter
 def base_markdown(value):
-    extensions = ["nl2br", ]
+    extensions = ["nl2br", "markdown.extensions.tables", ]
 
     return mark_safe(markdown.markdown(force_unicode(value),
                                        extensions,


### PR DESCRIPTION
I've tried the suggested function in #723 and it works.
![See screenshot](https://user-images.githubusercontent.com/642120/36571692-55e2be88-1838-11e8-9212-f0d2d17ed432.png)

Although, the PR solves the GFM issue, the remaining job before closing completely the issue would be to style tables as there are no borders or styles applied (screenshot can be misleading as I used a third party dev tools to highlight table and cells in red)
