### PR TITLE
Show example layout for a CSV file.

### DIFF
--- a/django_project/certification/templates/attendee/upload_attendee_csv.html
+++ b/django_project/certification/templates/attendee/upload_attendee_csv.html
@@ -30,7 +30,7 @@
             </div>
             <div class="col-lg-6">
                 <div class="header">
-                    <h3>Example here</h3>
+                    <h3>An example look of the file to be uploaded.</h3>
                     <blockquote>
                             <p>Please note that you need to upload a CSV (with a .csv extension) file
                                 with the following fields only and the fields needs to be seperated by a comma.</p>

--- a/django_project/certification/templates/attendee/upload_attendee_csv.html
+++ b/django_project/certification/templates/attendee/upload_attendee_csv.html
@@ -32,8 +32,8 @@
                 <div class="header">
                     <h3>Example here</h3>
                     <blockquote>
-                            <p>please not that you need to upload a CSV
-                                file with the following fields only and seperated by comma.</p>
+                            <p>Please note that you need to upload a CSV (with a .csv extension) file
+                                with the following fields only and the fields needs to be seperated by a comma.</p>
                     </blockquote>
                   <div class="row">
                       <div class="col-md-12">

--- a/django_project/certification/templates/attendee/upload_attendee_csv.html
+++ b/django_project/certification/templates/attendee/upload_attendee_csv.html
@@ -14,26 +14,28 @@
         </div>
         <div class="row">
             <div class="col-lg-6">
-                <form action="" method="post" name="file" enctype="multipart/form-data" class="form-horizontal">
+                <form action="" method="post" name="file" enctype="multipart/form-data" class="form-horizontal" style="margin-top: 10%">
                     {% csrf_token %}
                     <div class="form-group">
                         <div class="col-md-8">
                             {{ form.as_p }}
                         </div>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group" style="margin-right: 1500pt; margin-top: 30pt">
                         <div class="col-md-3 col-sm-3 col-xs-12 col-md-offset-3" style="margin-bottom:10px;">
-                            <button class="btn btn-primary"> <span class="glyphicon glyphicon-upload" style="margin-right:5px;"></span>Upload </button>
+                            <button class="btn btn-primary"> <span class="glyphicon glyphicon-upload" style="margin-right:5px;" type="file"></span>Upload </button>
                         </div>
                     </div>
                 </form>
             </div>
             <div class="col-lg-6">
                 <div class="header">
-                    <h3>An example look of the file to be uploaded.</h3>
+                    <h3>Format for the file to be uploaded:</h3>
                     <blockquote>
                             <p>Please note that you need to upload a CSV (with a .csv extension) file
-                                with the following fields only and the fields needs to be seperated by a comma.</p>
+                                with the following fields only and the fields needs to be seperated by a comma.
+                                The header row is not needed.
+                            </p>
                     </blockquote>
                   <div class="row">
                       <div class="col-md-12">

--- a/django_project/certification/templates/attendee/upload_attendee_csv.html
+++ b/django_project/certification/templates/attendee/upload_attendee_csv.html
@@ -12,18 +12,62 @@
         <div class="page-header">
             <h3>Upload Attendee Csv File.</h3>
         </div>
-        <form action="" method="post" name="file" enctype="multipart/form-data" class="form-horizontal">
-            {% csrf_token %}
-            <div class="form-group">
-                <div class="col-md-8">
-                    {{ form.as_p }}
+        <div class="row">
+            <div class="col-lg-6">
+                <form action="" method="post" name="file" enctype="multipart/form-data" class="form-horizontal">
+                    {% csrf_token %}
+                    <div class="form-group">
+                        <div class="col-md-8">
+                            {{ form.as_p }}
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-md-3 col-sm-3 col-xs-12 col-md-offset-3" style="margin-bottom:10px;">
+                            <button class="btn btn-primary"> <span class="glyphicon glyphicon-upload" style="margin-right:5px;"></span>Upload </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="col-lg-6">
+                <div class="header">
+                    <h3>Example here</h3>
+                    <blockquote>
+                            <p>please not that you need to upload a CSV
+                                file with the following fields only and seperated by comma.</p>
+                    </blockquote>
+                  <div class="row">
+                      <div class="col-md-12">
+                          <table class="table table-bordered">
+                              <thead class="thead-inverse">
+                                <tr>
+                                  <th>First Name</th>
+                                  <th>Surname</th>
+                                  <th>Email</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                <tr>
+                                  <td>first name<span id="comma">,</span></td>
+                            <td>surname<span id="comma">,</span></td>
+                                  <td>attendee@bar.com</td>
+                                </tr>
+                              <tr>
+                                  <td>foo<span id="comma">,</span></td>
+                            <td>last name<span id="comma">,</span></td>
+                                  <td>attendee2@bar.com</td>
+                                </tr>
+                              </tbody>
+                        </table>
+                      </div>
+                        <style>
+                            #comma {
+                                padding-left: 50pt;
+                            }
+
+                        </style>
+                  </div>
                 </div>
             </div>
-            <div class="form-group">
-                <div class="col-md-3 col-sm-3 col-xs-12 col-md-offset-3" style="margin-bottom:10px;">
-                    <button class="btn btn-primary"> <span class="glyphicon glyphicon-upload" style="margin-right:5px;"></span>Upload </button>
-                </div>
-            </div>
-        </form>
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Fix #753 

I have added a screen layout of an example view for the csv that we expect to be uploaded.

![csv_example](https://user-images.githubusercontent.com/10270148/36604224-cc77808c-18c5-11e8-9551-9571d4a78156.png)
