### PR TITLE
remove Python warning about psycopg2

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
-psycopg2
+psycopg2-binary
 Django>=1.8,<1.9
 django-countries==3.4.1
 django-crispy-forms==1.4.0


### PR DESCRIPTION
```
/usr/local/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning:
The psycopg2 wheel package will be renamed from release 2.8; 
in order to keep installing from binary please use "pip install psycopg2-binary" instead.
 For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```


But from the website: https://pypi.python.org/pypi/psycopg2-binary
> The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources.

So ?