### PR TITLE
Fix slug duplicates

### DIFF
--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -122,6 +122,7 @@ class CertifyingOrganisationAdmin(admin.ModelAdmin):
     """Certifying organisation admin model."""
 
     filter_horizontal = ('organisation_owners',)
+    search_fields = ['name']
 
     def queryset(self, request):
         """Ensure we use the correct manager.

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -16,6 +16,7 @@ from unidecode import unidecode
 from django.contrib.auth.models import User
 from django_countries.fields import CountryField
 import logging
+from certification.utilities import check_slug
 
 logger = logging.getLogger(__name__)
 
@@ -163,10 +164,10 @@ class CertifyingOrganisation(models.Model):
             filtered_words = [word for word in words if
                               word.lower() not in STOP_WORDS]
             # unidecode() represents special characters (unicode data) in ASCII
-            new_list = \
-                self.project.slug + ' ' + \
-                unidecode(' '.join(filtered_words))
-            self.slug = slugify(new_list)[:50]
+            new_list = unidecode(' '.join(filtered_words))
+            new_slug = slugify(new_list)[:50]
+            new_slug = check_slug(CertifyingOrganisation, new_slug)
+            self.slug = slugify(new_slug)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -166,7 +166,7 @@ class CertifyingOrganisation(models.Model):
             # unidecode() represents special characters (unicode data) in ASCII
             new_list = unidecode(' '.join(filtered_words))
             new_slug = slugify(new_list)[:50]
-            new_slug = check_slug(CertifyingOrganisation, new_slug)
+            new_slug = check_slug(CertifyingOrganisation.objects.all(), new_slug)
             self.slug = slugify(new_slug)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 

--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -166,7 +166,8 @@ class CertifyingOrganisation(models.Model):
             # unidecode() represents special characters (unicode data) in ASCII
             new_list = unidecode(' '.join(filtered_words))
             new_slug = slugify(new_list)[:50]
-            new_slug = check_slug(CertifyingOrganisation.objects.all(), new_slug)
+            new_slug = \
+                check_slug(CertifyingOrganisation.objects.all(), new_slug)
             self.slug = slugify(new_slug)[:50]
         super(CertifyingOrganisation, self).save(*args, **kwargs)
 

--- a/django_project/certification/utilities.py
+++ b/django_project/certification/utilities.py
@@ -2,13 +2,13 @@
 """Tools for Certification app."""
 
 
-def check_slug(model, slug):
+def check_slug(queryset, slug):
     """
     This function checks slug within a model and return a new incremented slug.
 
     """
 
-    registered_slug = model.objects.all().values_list('slug', flat=True)
+    registered_slug = queryset.values_list('slug', flat=True)
     new_slug = slug
     if slug in registered_slug:
         match_slug = [s for s in registered_slug if slug in s]

--- a/django_project/certification/utilities.py
+++ b/django_project/certification/utilities.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+"""Tools for Certification app."""
+
+
+def check_slug(model, slug):
+    """
+    This function checks slug within a model and return a new incremented slug.
+
+    """
+
+    registered_slug = model.objects.all().values_list('slug', flat=True)
+    new_slug = slug
+    if slug in registered_slug:
+        match_slug = [s for s in registered_slug if slug in s]
+        num = len(match_slug)
+        new_slug = str(num) + '-' + slug
+
+    return new_slug

--- a/django_project/certification/utilities.py
+++ b/django_project/certification/utilities.py
@@ -4,7 +4,8 @@
 
 def check_slug(queryset, slug):
     """
-    This function checks slug within a model and return a new incremented slug.
+    This function checks slug within a model queryset
+    and return a new incremented slug when there are duplicates.
 
     """
 

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -3,7 +3,7 @@ from base.models import Project
 from django.contrib import messages
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_list_or_404
 from django.db.models import Q
 from django.http import HttpResponse
 from django.views.generic import (
@@ -27,6 +27,7 @@ from ..models import (
     Course,
     Attendee)
 from ..forms import CertifyingOrganisationForm
+from certification.utilities import check_slug
 
 
 class JSONResponseMixin(object):
@@ -714,9 +715,16 @@ class ApproveCertifyingOrganisationView(
 
         certifyingorganisation_qs = \
             CertifyingOrganisation.unapproved_objects.all()
+        # Get the object, when there is slug duplicate, get the first object
         certifyingorganisation = \
-            get_object_or_404(certifyingorganisation_qs, slug=slug)
+            get_list_or_404(certifyingorganisation_qs, slug=slug)[0]
         certifyingorganisation.approved = True
+
+        # Check if slug have duplicates in approved objects.
+        # If there is duplicate slug, assign new slug.
+        slug = check_slug(CertifyingOrganisation, certifyingorganisation.slug)
+        certifyingorganisation.slug = slug
+
         certifyingorganisation.save()
 
         site = self.request.get_host()

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -722,7 +722,8 @@ class ApproveCertifyingOrganisationView(
 
         # Check if slug have duplicates in approved objects.
         # If there is duplicate slug, assign new slug.
-        slug = check_slug(CertifyingOrganisation, certifyingorganisation.slug)
+        approved_objects = CertifyingOrganisation.approved_objects.all()
+        slug = check_slug(approved_objects, certifyingorganisation.slug)
         certifyingorganisation.slug = slug
 
         certifyingorganisation.save()


### PR DESCRIPTION
fix #769 

- [x] Fixed problem when there is duplicates in certifying organisation slug.

Slug was created based upon project name and certifying organisation name, since they are unique together. However because project name and certifying organisation name are case sensitive and slug is made case insensitive, sometimes there could be duplicates. 
Example in project QGIS, we can create: Test organisation and test Organisation. Both will have same slug: qgis-test-organisation.

This PR change the slug creation using only certifying organisation name, and check if there is already same slug in the database for certifying organisation. When there are duplicates, the `check_slug` function will increment the slug.
So, for earlier example when we already have an object with slug `qgis-test-organisation`, the second object will have slug `1-qgis-test-organisation`

- [x] Fixed problem when in the existing database there is already two objects with the same slug.
When approving the certifying organisation, this will check if the object slug has duplicates in approved certifying organisation objects. When there are duplicates, it will update the slug with new incremented slug.