### PR TITLE
Make sure the pending category query set give distinct values.

### DIFF
--- a/django_project/changes/views/category.py
+++ b/django_project/changes/views/category.py
@@ -601,7 +601,8 @@ class PendingCategoryListView(
                 self.queryset = Category.unapproved_objects.filter(
                     Q(project=self.project) &
                     (Q(project__owner=self.request.user) |
-                     Q(project__changelog_managers=self.request.user)))
+                     Q(project__changelog_managers=self.request.user))
+                ).distinct()
                 return self.queryset
             else:
                 raise Http404(


### PR DESCRIPTION
Fix #803 

Reference : https://docs.djangoproject.com/en/1.8/ref/models/querysets/#django.db.models.query.QuerySet.distinct

> By default, a QuerySet will not eliminate duplicate rows. In practice, this is rarely a problem, because simple queries such as Blog.objects.all() don’t introduce the possibility of duplicate result rows. However, if your query spans multiple tables, it’s possible to get duplicate results when a QuerySet is evaluated. That’s when you’d use distinct().