### PR TITLE
register attendee and add it into course in the same screen

### DIFF
--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -28,7 +28,8 @@ class CertificateAdmin(admin.ModelAdmin):
 
 class AttendeeAdmin(admin.ModelAdmin):
     """Attendee admin model."""
-    list_display = ('firstname', 'surname', 'email')
+    list_display = ('firstname', 'surname', 'email', 'certifying_organisation')
+    search_fields = ['firstname', 'surname']
 
     def queryset(self, request):
         """Ensure we use the correct manager.

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -359,6 +359,12 @@ class CourseAttendeeForm(forms.ModelForm):
 
 class AttendeeForm(forms.ModelForm):
 
+    add_to_course = forms.BooleanField(
+        initial=True,
+        help_text='Add this attendee to course.',
+        required=False
+    )
+
     class Meta:
         model = Attendee
         fields = (
@@ -379,6 +385,7 @@ class AttendeeForm(forms.ModelForm):
                 Field('firstname', css_class='form-control'),
                 Field('surname', css_class='form-control'),
                 Field('email', css_class='form-control'),
+                Field('add_to_course', css_class='form-control')
             )
         )
         self.helper.layout = layout
@@ -387,6 +394,7 @@ class AttendeeForm(forms.ModelForm):
         self.fields['certifying_organisation'].initial = \
             self.certifying_organisation
         self.fields['certifying_organisation'].widget = forms.HiddenInput()
+        kwargs.update({'add_to_course': self.fields['add_to_course']})
         self.helper.add_input(Submit('submit', 'Add'))
 
     def save(self, commit=True):

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -394,7 +394,6 @@ class AttendeeForm(forms.ModelForm):
         self.fields['certifying_organisation'].initial = \
             self.certifying_organisation
         self.fields['certifying_organisation'].widget = forms.HiddenInput()
-        kwargs.update({'add_to_course': self.fields['add_to_course']})
         self.helper.add_input(Submit('submit', 'Add'))
 
     def save(self, commit=True):

--- a/django_project/certification/templates/attendee/create.html
+++ b/django_project/certification/templates/attendee/create.html
@@ -7,6 +7,15 @@
 {% endblock page_title %}
 
 {% block content %}
+    <style>
+        label[for=id_add_to_course] {
+            padding-left: 0 !important;
+            font-weight: bold !important;
+        }
+        label[for=id_add_to_course] p {
+            font-weight: normal !important;
+        }
+    </style>
     <section id="forms">
         <div class='container'>
             {% csrf_token %}

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -139,7 +139,7 @@
            href='{% url 'courseattendee-create' project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
             data-title="Add Course Attendees">
             {% show_button_icon "add" %}</a>
-         <a id='upload-attendee' class="btn btn-default btn-sm tooltip-toggle"
+         <a id='upload-attendee' class="btn btn-default btn-sm tooltip-toggle btn-info-focus"
            href='{% url "upload-attendee" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug slug=course.slug %}'
             data-title="Import Attendees from CSV file.">
             <span class="glyphicon glyphicon-import"></span>
@@ -204,7 +204,7 @@
                                     <a class="btn btn-default btn-xs tooltip-toggle btn-issue"
                                        href='{% url "paid-certificate" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug pk=attendee.attendee.pk %}'
                                         data-title="Pay this certificate using credits">
-                                        <i class="glyphicon glyphicon-import"></i></a>
+                                        <i class="fa fa-usd"></i></a>
                                 {% else %}
                                     <a class="btn btn-default btn-xs tooltip-toggle btn-top-up"
                                        href='{% url "top-up" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug %}'

--- a/django_project/certification/tests/test_attendee_views.py
+++ b/django_project/certification/tests/test_attendee_views.py
@@ -1,0 +1,148 @@
+# coding=utf-8
+from django.core.urlresolvers import reverse
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from base.tests.model_factories import ProjectF
+from certification.tests.model_factories import (
+    CertifyingOrganisationF,
+    TrainingCenterF,
+    CourseF,
+    CourseConvenerF,
+    CourseTypeF,
+)
+from core.model_factories import UserF
+import logging
+
+
+class TestCourseAttendeeView(TestCase):
+    """Tests that attendee and course attendee view works."""
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def setUp(self):
+        self.client = Client()
+        self.client.post(
+            '/set_language/', data={'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.project = ProjectF.create()
+        self.certifying_organisation = \
+            CertifyingOrganisationF.create(project=self.project)
+        self.training_center = \
+            TrainingCenterF.create(
+                certifying_organisation=self.certifying_organisation)
+        self.course_convener = \
+            CourseConvenerF.create(
+                certifying_organisation=self.certifying_organisation)
+        self.course_type = \
+            CourseTypeF.create(
+                certifying_organisation=self.certifying_organisation)
+        self.course = CourseF.create(
+            certifying_organisation=self.certifying_organisation,
+            training_center=self.training_center,
+            course_convener=self.course_convener,
+            course_type=self.course_type
+        )
+        self.user = UserF.create(**{
+            'username': 'anita',
+            'password': 'password',
+            'is_staff': True
+        })
+        self.user.set_password('password')
+        self.user.save()
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def tearDown(self):
+        """
+        Teardown after each test.
+
+        :return:
+        """
+        self.project.delete()
+        self.certifying_organisation.delete()
+        self.training_center.delete()
+        self.course_convener.delete()
+        self.course_type.delete()
+        self.course.delete()
+        self.user.delete()
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_AttendeeCreateView_no_login(self):
+        response = self.client.get(reverse('attendee-create', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug
+        }))
+        self.assertEqual(response.status_code, 302)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_AttendeeCreateView_with_login(self):
+        status = self.client.login(username='anita', password='password')
+        self.assertTrue(status)
+        url = reverse('attendee-create', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        expected_templates = [
+            'attendee/create.html'
+        ]
+        self.assertEqual(response.template_name, expected_templates)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_AttendeeAndCourseAttendeeCreate_with_login(self):
+        """
+        Test create attendee that automatically create course attendee
+        from this newly created attendee object.
+
+        """
+        self.client.login(username='anita', password='password')
+        post_data = {
+            'firstname': u'Test',
+            'surname': u'Course-Attendee',
+            'email': u'test@test.com',
+            'certifying_organisation': self.certifying_organisation.id,
+            'add_to_course': True,
+        }
+        response = self.client.post(reverse('attendee-create', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug
+        }), post_data)
+        self.assertRedirects(
+            response,
+            reverse(
+                'course-detail',
+                kwargs={
+                    'project_slug': self.project.slug,
+                    'organisation_slug': self.certifying_organisation.slug,
+                    'slug': self.course.slug
+                }))
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_AttendeeOnlyCreate_with_login(self):
+        """
+        Test create attendee only.
+
+        """
+        self.client.login(username='anita', password='password')
+        post_data = {
+            'firstname': u'Test',
+            'surname': u'Attendee',
+            'email': u'test@test.com',
+            'certifying_organisation': self.certifying_organisation.id,
+        }
+        response = self.client.post(reverse('attendee-create', kwargs={
+            'project_slug': self.project.slug,
+            'organisation_slug': self.certifying_organisation.slug,
+            'slug': self.course.slug
+        }), post_data)
+        self.assertRedirects(
+            response,
+            reverse(
+                'courseattendee-create',
+                kwargs={
+                    'project_slug': self.project.slug,
+                    'organisation_slug': self.certifying_organisation.slug,
+                    'slug': self.course.slug
+                }))

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -2,7 +2,6 @@
 import csv
 from django.db import transaction
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
 from django.views.generic import (
     CreateView, FormView)
 from braces.views import LoginRequiredMixin, FormMessagesMixin

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -2,6 +2,7 @@
 import csv
 from django.db import transaction
 from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 from django.views.generic import (
     CreateView, FormView)
 from braces.views import LoginRequiredMixin, FormMessagesMixin
@@ -33,12 +34,20 @@ class AttendeeCreateView(LoginRequiredMixin, AttendeeMixin, CreateView):
        :returns: URL
        :rtype: HttpResponse
        """
-
-        return reverse('courseattendee-create', kwargs={
-            'project_slug': self.project_slug,
-            'organisation_slug': self.organisation_slug,
-            'slug': self.course_slug,
-        })
+        add_to_course = self.request.POST.get('add_to_course')
+        if add_to_course is None:
+            success_url = reverse('courseattendee-create', kwargs={
+                'project_slug': self.project_slug,
+                'organisation_slug': self.organisation_slug,
+                'slug': self.course_slug,
+            })
+        else:
+            success_url = reverse('course-detail', kwargs={
+                'project_slug': self.project_slug,
+                'organisation_slug': self.organisation_slug,
+                'slug': self.course_slug,
+            })
+        return success_url
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.
@@ -72,6 +81,24 @@ class AttendeeCreateView(LoginRequiredMixin, AttendeeMixin, CreateView):
             'certifying_organisation': self.certifying_organisation
         })
         return kwargs
+
+    def form_valid(self, form):
+        add_to_course = self.request.POST.get('add_to_course')
+        if add_to_course is None:
+            if form.is_valid():
+                form.save()
+        else:
+            if form.is_valid():
+                object = form.save()
+                course_slug = self.kwargs.get('slug', None)
+                course = Course.objects.get(slug=course_slug)
+                course_attendee = CourseAttendee(
+                    attendee=object,
+                    course=course,
+                    author=self.request.user
+                )
+                course_attendee.save()
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class CsvUploadView(FormMessagesMixin, LoginRequiredMixin, FormView):

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -98,7 +98,7 @@ class AttendeeCreateView(LoginRequiredMixin, AttendeeMixin, CreateView):
                     author=self.request.user
                 )
                 course_attendee.save()
-        return HttpResponseRedirect(self.get_success_url())
+        return super(AttendeeCreateView, self).form_valid(form)
 
 
 class CsvUploadView(FormMessagesMixin, LoginRequiredMixin, FormView):


### PR DESCRIPTION
fix #556 

Add new attendee and automatically add the newly created attendee into course:
![peek 2018-03-06 10-50](https://user-images.githubusercontent.com/26101337/37013804-bcec5efa-212e-11e8-87fc-6967b02daca6.gif)

Only add new attendee:
![peek 2018-03-06 10-52](https://user-images.githubusercontent.com/26101337/37013816-d3d03a1a-212e-11e8-8443-1f23a55a8b46.gif)

Also changed icons in course details, because there are two identical icons for different purpose:
one was for uploading new attendee using csv file and the other one for paying unpaid certificate
![screenshot from 2018-03-06 10-54-43](https://user-images.githubusercontent.com/26101337/37013834-ffa2fe3e-212e-11e8-9bb2-842faf70ecdf.png)

I changed it into this:
![screenshot from 2018-03-06 11-04-59](https://user-images.githubusercontent.com/26101337/37013837-052d1920-212f-11e8-9ad2-c388dff34bee.png)
