### PR TITLE
Fix #797. Error 500: Editing Answers.

### DIFF
--- a/django_project/lesson/views/answer.py
+++ b/django_project/lesson/views/answer.py
@@ -104,7 +104,7 @@ class AnswerUpdateView(
         :rtype: dict
         """
         kwargs = super(AnswerUpdateView, self).get_form_kwargs()
-        answer = get_object_or_404(Answer, self.pk_url_kwarg)
+        answer = get_object_or_404(Answer, pk=kwargs['instance'].pk)
         kwargs['question'] = answer.question
         return kwargs
 


### PR DESCRIPTION
Fix #797
 It expects keywords arguments. `self.pk_url_kwarg == 'pk'`. So, for some reasons, it resolves it as `p=k`