### PR TITLE
fix changelog entry detail permission

### DIFF
--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -21,6 +21,7 @@
     <div class="row" style="margin-top:15px;margin-bottom:15px;">
         <div class="col-lg-12">
             <div class="btn-group btn-group pull-left">
+                {% if user_can_edit %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        data-title="Download sponsor list as html"
                        href='{% url 'version-sponsor-download' project_slug=version.project.slug slug=version.slug %}'>
@@ -33,6 +34,7 @@
                         <span class="glyphicon glyphicon-download"></span>
                         <span style="font-size: 7pt;">R S T</span>
                     </a>
+                {% endif %}
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Download as GNU Changelog" data-toggle="tooltip"
                    href='{% url 'version-download-gnu' project_slug=version.project.slug slug=version.slug %}'>

--- a/django_project/changes/templates/version/detail.html
+++ b/django_project/changes/templates/version/detail.html
@@ -21,7 +21,6 @@
     <div class="row" style="margin-top:15px;margin-bottom:15px;">
         <div class="col-lg-12">
             <div class="btn-group btn-group pull-left">
-                {% if user_can_edit %}
                     <a class="btn btn-default btn-mini tooltip-toggle"
                        data-title="Download sponsor list as html"
                        href='{% url 'version-sponsor-download' project_slug=version.project.slug slug=version.slug %}'>
@@ -34,7 +33,6 @@
                         <span class="glyphicon glyphicon-download"></span>
                         <span style="font-size: 7pt;">R S T</span>
                     </a>
-                {% endif %}
                 <a class="btn btn-default btn-mini tooltip-toggle"
                    data-title="Download as GNU Changelog" data-toggle="tooltip"
                    href='{% url 'version-download-gnu' project_slug=version.project.slug slug=version.slug %}'>

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -170,6 +170,8 @@ class VersionDetailView(VersionMixin, DetailView):
                 sponsors[sponsor.sponsorship_level].append(sponsor.sponsor)
 
         context['sponsors'] = sponsors
+        context['user_can_edit'] =False
+        context['user_can_delete'] = False
         project_slug = self.kwargs.get('project_slug', None)
         context['project_slug'] = project_slug
         if project_slug:

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -170,7 +170,7 @@ class VersionDetailView(VersionMixin, DetailView):
                 sponsors[sponsor.sponsorship_level].append(sponsor.sponsor)
 
         context['sponsors'] = sponsors
-        context['user_can_edit'] =False
+        context['user_can_edit'] = False
         context['user_can_delete'] = False
         project_slug = self.kwargs.get('project_slug', None)
         context['project_slug'] = project_slug

--- a/django_project/changes/views/version.py
+++ b/django_project/changes/views/version.py
@@ -175,6 +175,23 @@ class VersionDetailView(VersionMixin, DetailView):
         if project_slug:
             context['project'] = Project.objects.get(slug=project_slug)
 
+        # lets check for specific user permissions here.
+        if self.request.user.is_staff:
+            context['user_can_edit'] = True
+            context['user_can_delete'] = True
+
+        if self.request.user.is_superuser:
+            context['user_can_edit'] = True
+            context['user_can_delete'] = True
+
+        if context['project'].changelog_managers.filter(
+                project__owner=self.request.user.id).exists():
+            context['user_can_edit'] = True
+            context['user_can_delete'] = True
+
+        if self.request.user == context['project'].owner:
+            context['user_can_edit'] = True
+            context['user_can_delete'] = True
         return context
 
     def get_queryset(self):


### PR DESCRIPTION
fix #826 

We needed to fix our new permission checks on the changelog entry detail too.
## logged in as owner

![fix_version](https://user-images.githubusercontent.com/10270148/37202310-d6b1dd90-2392-11e8-8aa9-10ec3e138f10.png)

## not logged in
![unloged](https://user-images.githubusercontent.com/10270148/37204517-b786c73a-2399-11e8-8d73-4525386ebfc5.png)

