### PR TITLE
Update table style using Boostrap & a custom class for header

### DIFF
--- a/django_project/base/templatetags/custom_markup.py
+++ b/django_project/base/templatetags/custom_markup.py
@@ -18,7 +18,7 @@ def base_markdown(value):
         safe_mode=True,
         enable_attributes=False)
     html_output = html_output.replace(
-        '<table>', '<table class="markdown-table"')
+        '<table>', '<table class="table table-striped table-bordered"')
     return mark_safe(html_output)
 
 

--- a/django_project/core/base_static/css/changelog.css
+++ b/django_project/core/base_static/css/changelog.css
@@ -139,13 +139,8 @@ ul.ui-sortable-disabled .order{
     max-width: 100%;
 }
 
-.markdown-table {
-    border-collapse: collapse;
-}
-
-.markdown-table, .markdown-table th, .markdown-table td {
-    border: 1px solid black;
-    padding: 1px;
+.table tbody:first-of-type tr {
+    background-color: #d6e6fb;
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
Due to #723 follow-up

For reviewing, see the options I've choose to use at https://getbootstrap.com/docs/4.0/content/tables/, in particular for "Striped rows" (maybe you may not want)

The transformation from markdown to table generate two `<tbody>` instead of a `<theader>` & a `<tbody>`. It's the why I've made a change in the CSS file too.