### PR TITLE
Tests for creating multiple organisation.

### DIFF
--- a/django_project/base/tests/__init__.py
+++ b/django_project/base/tests/__init__.py
@@ -1,1 +1,3 @@
+# coding=utf-8
+"""Test for base App."""
 __author__ = 'timlinux'

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -274,24 +274,20 @@ class TestOrganisationCreate(TestCase):
         # Test that user is actually loged in.
         self.assertTrue(loged_in)
 
-        post_data = {
-            'name': u'Test organisation creation'
-        }
-        post_data_2 = {
-            'name': u'Test organisation creation two'
-        }
-        post_data_3 = {
-            'name': u'Test organisation creation three'
-        }
+        post_data_list = [
+            'Test organisation creation',
+            'Test organisation creation two',
+            'Test organisation creation three']
 
-        response = client.post(reverse('create-organisation'), post_data)
-        self.assertEqual(response.status_code, 302)
+        for post_data in post_data_list:
+            response = client.post(reverse('create-organisation'),
+                                   {'name': post_data})
+            self.assertEqual(response.status_code, 302)
 
-        response = client.post(reverse('create-organisation'), post_data_2)
-        self.assertEqual(response.status_code, 302)
+            response = client.post(reverse('create-organisation'),
+                                   {'name': post_data})
+            self.assertEqual(response.status_code, 302)
 
-        response = client.post(reverse('create-organisation'), post_data_3)
-        self.assertEqual(response.status_code, 302)
 
     @override_settings(VALID_DOMAIN = ['testserver', ])
     def test_organisation_create_with_no_login(self):

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -273,7 +273,6 @@ class TestOrganisationCreate(TestCase):
 
         # Test that user is actually loged in.
         self.assertTrue(loged_in)
-
         post_data_list = [
             'Test organisation creation',
             'Test organisation creation two',
@@ -283,11 +282,6 @@ class TestOrganisationCreate(TestCase):
             response = client.post(reverse('create-organisation'),
                                    {'name': post_data})
             self.assertEqual(response.status_code, 302)
-
-            response = client.post(reverse('create-organisation'),
-                                   {'name': post_data})
-            self.assertEqual(response.status_code, 302)
-
 
     @override_settings(VALID_DOMAIN = ['testserver', ])
     def test_organisation_create_with_no_login(self):
@@ -353,7 +347,6 @@ class TestOrganisationCreateWithSuperuserPermissions(TestCase):
 
         # Test that user is actually loged in.
         self.assertTrue(loged_in)
-
         post_data_list = [
             'Test organisation creation',
             'Test organisation creation two',
@@ -416,22 +409,12 @@ class TestOrganisationCreateWithNoneStaffPermissions(TestCase):
 
         # Test that user is actually loged in.
         self.assertTrue(loged_in)
+        post_data_list = [
+            'Test organisation creation',
+            'Test organisation creation two',
+            'Test organisation creation three']
 
-        post_data = {
-            'name': u'Test organisation creation'
-        }
-        post_data_2 = {
-            'name': u'Test organisation creation two'
-        }
-        post_data_3 = {
-            'name': u'Test organisation creation three'
-        }
-
-        response = client.post(reverse('create-organisation'), post_data)
-        self.assertEqual(response.status_code, 302)
-
-        response = client.post(reverse('create-organisation'), post_data_2)
-        self.assertEqual(response.status_code, 302)
-
-        response = client.post(reverse('create-organisation'), post_data_3)
-        self.assertEqual(response.status_code, 302)
+        for post_data in post_data_list:
+            response = client.post(reverse('create-organisation'),
+                                   {'name': post_data})
+            self.assertEqual(response.status_code, 302)

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -221,9 +221,7 @@ class TestViews(TestCase):
 
 
 class TestOrganisationCreate(TestCase):
-    """
-    Test Multiple organisation creation from a single login account.
-    """
+    """Test organisation creation."""
     @override_settings(VALID_DOMAIN=['testserver', ])
     def setUp(self):
         """Setting up before each test."""
@@ -247,9 +245,7 @@ class TestOrganisationCreate(TestCase):
     @override_settings(VALID_DOMAIN=[ 'testserver' ])
     def test_oroganisation_create_with_login(self):
         """
-        Test creation of more than one organisation from a single logged
-        in account.
-
+        Test that a single logged in user can create multiple organisations.
         """
         client = Client()
         loged_in = client.login(username='sonlinux', password='password')

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -222,14 +222,14 @@ class TestViews(TestCase):
 
 class TestOrganisationCreate(TestCase):
     """Test organisation creation."""
-    @override_settings(VALID_DOMAIN=['testserver', ])
+    @override_settings(VALID_DOMAIN=['testserver',])
     def setUp(self):
         """Setting up before each test."""
         self.client = Client()
         self.client.post(
-                '/set_language/', data = { 'language': 'en' })
+                '/set_language/', data = {'language': 'en'})
         logging.disable(logging.CRITICAL)
-        self.user = UserF.create( **{
+        self.user = UserF.create(**{
             'username': 'sonlinux',
             'is_staff': True,
         })
@@ -242,7 +242,7 @@ class TestOrganisationCreate(TestCase):
         self.unapproved_project = ProjectF.create(approved=False)
         self.test_organisation = OrganisationF.create()
 
-    @override_settings(VALID_DOMAIN=[ 'testserver' ])
+    @override_settings(VALID_DOMAIN=['testserver' ])
     def test_oroganisation_create_with_login(self):
         """
         Test that a single logged in user can create multiple organisations.
@@ -257,12 +257,12 @@ class TestOrganisationCreate(TestCase):
             'organisation/create.html'
         ]
         response = client.post(reverse( 'create-organisation' ))
-        self.assertEqual(response.status_code , 200)
+        self.assertEqual(response.status_code, 200)
 
         # Test if get the correct template view after creation.
-        self.assertEqual(response.template_name , expected_templates)
+        self.assertEqual(response.template_name, expected_templates)
 
-    @override_settings(VALID_DOMAIN = [ 'testserver', ])
+    @override_settings(VALID_DOMAIN = ['testserver',])
     def test_multiple_organisation_create_with_single_login(self):
         """
         Test that a single logged in user can create multiple
@@ -282,20 +282,19 @@ class TestOrganisationCreate(TestCase):
             'name': u'Test organisation creation two'
         }
         post_data_3 = {
-            'name' : u'Test organisation creation three'
+            'name': u'Test organisation creation three'
         }
 
-        response = client.post(reverse('create-organisation') , post_data)
-        self.assertEqual(response.status_code , 302)
+        response = client.post(reverse('create-organisation'), post_data)
+        self.assertEqual(response.status_code, 302)
 
-        response = client.post(reverse('create-organisation') ,
-                                post_data_2)
-        self.assertEqual(response.status_code , 302)
+        response = client.post(reverse('create-organisation'), post_data_2)
+        self.assertEqual(response.status_code, 302)
 
         response = client.post(reverse('create-organisation'), post_data_3)
-        self.assertEqual(response.status_code , 302)
+        self.assertEqual(response.status_code, 302)
 
-    @override_settings(VALID_DOMAIN = [ 'testserver' , ])
+    @override_settings(VALID_DOMAIN = ['testserver',])
     def test_organisation_create_with_no_login(self):
         """Test that no non-authenticated user can create an organisation."""
         client = Client()
@@ -303,5 +302,5 @@ class TestOrganisationCreate(TestCase):
             'name': u'A new test organisation',
         }
         # response = client.post( reverse( 'account_login') , post_data )
-        response = client.post(reverse('create-organisation') , post_data)
-        self.assertEqual(response.status_code , 302)
+        response = client.post(reverse('create-organisation'), post_data)
+        self.assertEqual(response.status_code, 302)

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -222,7 +222,7 @@ class TestViews(TestCase):
 
 class TestOrganisationCreate(TestCase):
     """Test organisation creation."""
-    @override_settings(VALID_DOMAIN=['testserver',])
+    @override_settings(VALID_DOMAIN=['testserver', ])
     def setUp(self):
         """Setting up before each test."""
         self.client = Client()
@@ -242,7 +242,7 @@ class TestOrganisationCreate(TestCase):
         self.unapproved_project = ProjectF.create(approved=False)
         self.test_organisation = OrganisationF.create()
 
-    @override_settings(VALID_DOMAIN=['testserver' ])
+    @override_settings(VALID_DOMAIN=['testserver', ])
     def test_oroganisation_create_with_login(self):
         """
         Test that a single logged in user can create multiple organisations.
@@ -262,7 +262,7 @@ class TestOrganisationCreate(TestCase):
         # Test if get the correct template view after creation.
         self.assertEqual(response.template_name, expected_templates)
 
-    @override_settings(VALID_DOMAIN = ['testserver',])
+    @override_settings(VALID_DOMAIN = ['testserver', ])
     def test_multiple_organisation_create_with_single_login(self):
         """
         Test that a single logged in user can create multiple
@@ -294,7 +294,7 @@ class TestOrganisationCreate(TestCase):
         response = client.post(reverse('create-organisation'), post_data_3)
         self.assertEqual(response.status_code, 302)
 
-    @override_settings(VALID_DOMAIN = ['testserver',])
+    @override_settings(VALID_DOMAIN = ['testserver', ])
     def test_organisation_create_with_no_login(self):
         """Test that no non-authenticated user can create an organisation."""
         client = Client()

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -279,30 +279,25 @@ class TestOrganisationCreate(TestCase):
         self.assertTrue(loged_in)
 
         post_data = {
-            'name': u'Test organisation creation',
+            'name': u'Test organisation creation'
         }
-        response = client.post( reverse( 'create-organisation' ), post_data )
-        self.assertEqual( response.status_code , 302 )
-
         post_data_2 = {
 
-            'name2': u'Test organisation creation two',
+            'name': u'Test organisation creation two'
         }
+        post_data_3 = {
+            'name' : u'Test organisation creation three'
+        }
+
+        response = client.post( reverse( 'create-organisation' ) , post_data )
+        self.assertEqual( response.status_code , 302 )
+
         response = client.post( reverse( 'create-organisation' ) ,
                                 post_data_2 )
-        self.assertEqual( response.status_code, 200 )
-
-        post_data_3 = {
-            'name3' : u'Test organisation creation three',
-        }
+        self.assertEqual( response.status_code , 302 )
 
         response = client.post( reverse( 'create-organisation' ), post_data_3 )
-        self.assertEqual( response.status_code , 200 )
-
-        expected_templates = [
-            'organisation/create', u'base/organisation_create.html'
-        ]
-        # self.assertEqual(response.template_name, expected_templates)
+        self.assertEqual( response.status_code , 302 )
 
     @override_settings( VALID_DOMAIN = [ 'testserver' , ] )
     def test_organisation_create_with_no_login(self):

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -304,3 +304,151 @@ class TestOrganisationCreate(TestCase):
         # response = client.post( reverse( 'account_login') , post_data )
         response = client.post(reverse('create-organisation'), post_data)
         self.assertEqual(response.status_code, 302)
+
+
+class TestOrganisationCreateWithSuperuserPermissions(TestCase):
+    """Test organisation creation with a superuser login."""
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def setUp(self):
+        """Setting up before each test."""
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data = {'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.user = UserF.create(**{
+            'username': 'sonlinux',
+            'is_superuser': True,
+        })
+
+        self.user.set_password('password')
+        self.user.save()
+
+        # lets set up a testing project to create organisations from.
+        self.test_project = ProjectF.create()
+        self.unapproved_project = ProjectF.create(approved=False)
+        self.test_organisation = OrganisationF.create()
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_oroganisation_create_with_superuser(self):
+        """
+        Test that a superuser login can create multiple organisations.
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test client log in.
+        self.assertTrue(loged_in)
+
+        expected_templates = [
+            'organisation/create.html'
+        ]
+        response = client.post(reverse('create-organisation'))
+        self.assertEqual(response.status_code, 200)
+
+        # Test if get the correct template view after creation.
+        self.assertEqual(response.template_name, expected_templates)
+
+    @override_settings(VALID_DOMAIN = ['testserver', ])
+    def test_multiple_organisation_create_with_superuser(self):
+        """
+        Test that a superuser login can create multiple organisations.
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test that user is actually loged in.
+        self.assertTrue(loged_in)
+
+        post_data = {
+            'name': u'Test organisation creation'
+        }
+        post_data_2 = {
+
+            'name': u'Test organisation creation two'
+        }
+        post_data_3 = {
+            'name': u'Test organisation creation three'
+        }
+
+        response = client.post(reverse('create-organisation'), post_data)
+        self.assertEqual(response.status_code, 302)
+
+        response = client.post(reverse('create-organisation'), post_data_2)
+        self.assertEqual(response.status_code, 302)
+
+        response = client.post(reverse('create-organisation'), post_data_3)
+        self.assertEqual(response.status_code, 302)
+
+
+class TestOrganisationCreateWithNoneStaffPermissions(TestCase):
+    """Test organisation creation with a none staff user."""
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def setUp(self):
+        """Setting up before each test."""
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data = {'language': 'en'})
+        logging.disable(logging.CRITICAL)
+        self.user = UserF.create(**{
+            'username': 'sonlinux',
+            'is_staff': False,
+        })
+
+        self.user.set_password('password')
+        self.user.save()
+
+        # lets set up a testing project to create organisations from.
+        self.test_project = ProjectF.create()
+        self.unapproved_project = ProjectF.create(approved=False)
+        self.test_organisation = OrganisationF.create()
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_oroganisation_create_with_none_staff_login(self):
+        """
+        Test that a none staff user can create an organisations.
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test client log in.
+        self.assertTrue(loged_in)
+
+        expected_templates = [
+            'organisation/create.html'
+        ]
+        response = client.post(reverse('create-organisation'))
+        self.assertEqual(response.status_code, 200)
+
+        # Test if get the correct template view after creation.
+        self.assertEqual(response.template_name, expected_templates)
+
+    @override_settings(VALID_DOMAIN = ['testserver', ])
+    def test_multiple_organisation_create_with_none_staff_user(self):
+        """
+        Test that a none staff user can create multiple organisations.
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test that user is actually loged in.
+        self.assertTrue(loged_in)
+
+        post_data = {
+            'name': u'Test organisation creation'
+        }
+        post_data_2 = {
+
+            'name': u'Test organisation creation two'
+        }
+        post_data_3 = {
+            'name': u'Test organisation creation three'
+        }
+
+        response = client.post(reverse('create-organisation'), post_data)
+        self.assertEqual(response.status_code, 302)
+
+        response = client.post(reverse('create-organisation'), post_data_2)
+        self.assertEqual(response.status_code, 302)
+
+        response = client.post(reverse('create-organisation'), post_data_3)
+        self.assertEqual(response.status_code, 302)

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -218,3 +218,100 @@ class TestViews(TestCase):
             'github/populate-github.html'
         ]
         self.assertEqual(response.template_name, expected_templates)
+
+
+class TestOrganisationCreate(TestCase):
+    """
+    Test Multiple organisation creation from a single login account.
+    """
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def setUp(self):
+        """Setting up before each test."""
+        self.client = Client()
+        self.client.post(
+                '/set_language/', data = { 'language': 'en' } )
+        logging.disable( logging.CRITICAL )
+        self.user = UserF.create( **{
+            'username': 'sonlinux',
+            'is_staff': True,
+        } )
+
+        self.user.set_password( 'password' )
+        self.user.save()
+
+        # lets set up a testing project to create organisations from.
+        self.test_project = ProjectF.create()
+        self.unapproved_project = ProjectF.create( approved=False )
+        self.test_organisation = OrganisationF.create()
+
+    @override_settings(VALID_DOMAIN=[ 'testserver' ] )
+    def test_oroganisation_create_with_login(self):
+        """
+        Test creation of more than one organisation from a single logged
+        in account.
+
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test client log in.
+        self.assertTrue(loged_in)
+
+        expected_templates = [
+            'organisation/create.html'
+        ]
+        response = client.post( reverse( 'create-organisation' ) )
+        self.assertEqual( response.status_code , 200 )
+
+        # Test if get the correct template view after creation.
+        self.assertEqual( response.template_name , expected_templates )
+
+    @override_settings( VALID_DOMAIN = [ 'testserver', ] )
+    def test_multiple_organisation_create_with_single_login(self):
+        """
+        Test that a single logged in user can create multiple
+        organisations.
+        """
+        client = Client()
+        loged_in = client.login(username='sonlinux', password='password')
+
+        # Test that user is actually loged in.
+        self.assertTrue(loged_in)
+
+        post_data = {
+            'name': u'Test organisation creation',
+        }
+        response = client.post( reverse( 'create-organisation' ), post_data )
+        self.assertEqual( response.status_code , 302 )
+
+        post_data_2 = {
+
+            'name2': u'Test organisation creation two',
+        }
+        response = client.post( reverse( 'create-organisation' ) ,
+                                post_data_2 )
+        self.assertEqual( response.status_code, 200 )
+
+        post_data_3 = {
+            'name3' : u'Test organisation creation three',
+        }
+
+        response = client.post( reverse( 'create-organisation' ), post_data_3 )
+        self.assertEqual( response.status_code , 200 )
+
+        expected_templates = [
+            'organisation/create', u'base/organisation_create.html'
+        ]
+        # self.assertEqual(response.template_name, expected_templates)
+
+    @override_settings( VALID_DOMAIN = [ 'testserver' , ] )
+    def test_organisation_create_with_no_login(self):
+        """Test that no non-authenticated user can create an organisation."""
+        client = Client()
+        post_data = {
+            'name': u'A new test organisation',
+        }
+        # response = client.post( reverse( 'account_login') , post_data )
+        response = client.post( reverse( 'create-organisation' ) , post_data )
+        self.assertEqual( response.status_code , 302 )
+

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -229,22 +229,22 @@ class TestOrganisationCreate(TestCase):
         """Setting up before each test."""
         self.client = Client()
         self.client.post(
-                '/set_language/', data = { 'language': 'en' } )
-        logging.disable( logging.CRITICAL )
+                '/set_language/', data = { 'language': 'en' })
+        logging.disable(logging.CRITICAL)
         self.user = UserF.create( **{
             'username': 'sonlinux',
             'is_staff': True,
-        } )
+        })
 
-        self.user.set_password( 'password' )
+        self.user.set_password('password')
         self.user.save()
 
         # lets set up a testing project to create organisations from.
         self.test_project = ProjectF.create()
-        self.unapproved_project = ProjectF.create( approved=False )
+        self.unapproved_project = ProjectF.create(approved=False)
         self.test_organisation = OrganisationF.create()
 
-    @override_settings(VALID_DOMAIN=[ 'testserver' ] )
+    @override_settings(VALID_DOMAIN=[ 'testserver' ])
     def test_oroganisation_create_with_login(self):
         """
         Test creation of more than one organisation from a single logged
@@ -260,13 +260,13 @@ class TestOrganisationCreate(TestCase):
         expected_templates = [
             'organisation/create.html'
         ]
-        response = client.post( reverse( 'create-organisation' ) )
-        self.assertEqual( response.status_code , 200 )
+        response = client.post(reverse( 'create-organisation' ))
+        self.assertEqual(response.status_code , 200)
 
         # Test if get the correct template view after creation.
-        self.assertEqual( response.template_name , expected_templates )
+        self.assertEqual(response.template_name , expected_templates)
 
-    @override_settings( VALID_DOMAIN = [ 'testserver', ] )
+    @override_settings(VALID_DOMAIN = [ 'testserver', ])
     def test_multiple_organisation_create_with_single_login(self):
         """
         Test that a single logged in user can create multiple
@@ -289,17 +289,17 @@ class TestOrganisationCreate(TestCase):
             'name' : u'Test organisation creation three'
         }
 
-        response = client.post( reverse( 'create-organisation' ) , post_data )
-        self.assertEqual( response.status_code , 302 )
+        response = client.post(reverse('create-organisation') , post_data)
+        self.assertEqual(response.status_code , 302)
 
-        response = client.post( reverse( 'create-organisation' ) ,
-                                post_data_2 )
-        self.assertEqual( response.status_code , 302 )
+        response = client.post(reverse('create-organisation') ,
+                                post_data_2)
+        self.assertEqual(response.status_code , 302)
 
-        response = client.post( reverse( 'create-organisation' ), post_data_3 )
-        self.assertEqual( response.status_code , 302 )
+        response = client.post(reverse('create-organisation'), post_data_3)
+        self.assertEqual(response.status_code , 302)
 
-    @override_settings( VALID_DOMAIN = [ 'testserver' , ] )
+    @override_settings(VALID_DOMAIN = [ 'testserver' , ])
     def test_organisation_create_with_no_login(self):
         """Test that no non-authenticated user can create an organisation."""
         client = Client()
@@ -307,6 +307,5 @@ class TestOrganisationCreate(TestCase):
             'name': u'A new test organisation',
         }
         # response = client.post( reverse( 'account_login') , post_data )
-        response = client.post( reverse( 'create-organisation' ) , post_data )
-        self.assertEqual( response.status_code , 302 )
-
+        response = client.post(reverse('create-organisation') , post_data)
+        self.assertEqual(response.status_code , 302)

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -256,7 +256,7 @@ class TestOrganisationCreate(TestCase):
         expected_templates = [
             'organisation/create.html'
         ]
-        response = client.post(reverse( 'create-organisation' ))
+        response = client.post(reverse('create-organisation'))
         self.assertEqual(response.status_code, 200)
 
         # Test if get the correct template view after creation.

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -278,7 +278,6 @@ class TestOrganisationCreate(TestCase):
             'name': u'Test organisation creation'
         }
         post_data_2 = {
-
             'name': u'Test organisation creation two'
         }
         post_data_3 = {
@@ -359,25 +358,15 @@ class TestOrganisationCreateWithSuperuserPermissions(TestCase):
         # Test that user is actually loged in.
         self.assertTrue(loged_in)
 
-        post_data = {
-            'name': u'Test organisation creation'
-        }
-        post_data_2 = {
+        post_data_list = [
+            'Test organisation creation',
+            'Test organisation creation two',
+            'Test organisation creation three']
 
-            'name': u'Test organisation creation two'
-        }
-        post_data_3 = {
-            'name': u'Test organisation creation three'
-        }
-
-        response = client.post(reverse('create-organisation'), post_data)
-        self.assertEqual(response.status_code, 302)
-
-        response = client.post(reverse('create-organisation'), post_data_2)
-        self.assertEqual(response.status_code, 302)
-
-        response = client.post(reverse('create-organisation'), post_data_3)
-        self.assertEqual(response.status_code, 302)
+        for post_data in post_data_list:
+            response = client.post(reverse('create-organisation'),
+                                   {'name': post_data})
+            self.assertEqual(response.status_code, 302)
 
 
 class TestOrganisationCreateWithNoneStaffPermissions(TestCase):
@@ -404,9 +393,8 @@ class TestOrganisationCreateWithNoneStaffPermissions(TestCase):
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_oroganisation_create_with_none_staff_login(self):
-        """
-        Test that a none staff user can create an organisations.
-        """
+        """Test that a none staff user can create an organisations."""
+
         client = Client()
         loged_in = client.login(username='sonlinux', password='password')
 
@@ -437,7 +425,6 @@ class TestOrganisationCreateWithNoneStaffPermissions(TestCase):
             'name': u'Test organisation creation'
         }
         post_data_2 = {
-
             'name': u'Test organisation creation two'
         }
         post_data_3 = {

--- a/django_project/core/settings/__init__.py
+++ b/django_project/core/settings/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8


### PR DESCRIPTION
fix #768 

- [x] Passing tests for the base module to certify that a single user login can create more than one organisation.

![various_accounts](https://user-images.githubusercontent.com/10270148/37821057-3addf634-2e8b-11e8-83c6-c77fa70d8eea.png)

