### PR TITLE
project approved by default

### DIFF
--- a/django_project/base/forms.py
+++ b/django_project/base/forms.py
@@ -147,6 +147,7 @@ class ProjectForm(forms.ModelForm):
 
     def save(self, commit=True):
         instance = super(ProjectForm, self).save(commit=False)
+        instance.approved = True
         instance.owner = self.user
         instance.save()
         self.save_m2m()

--- a/django_project/base/tests/test_views.py
+++ b/django_project/base/tests/test_views.py
@@ -81,7 +81,7 @@ class TestViews(TestCase):
             'organisation': self.test_organisation.id,
         }
         response = client.post(reverse('project-create'), post_data)
-        self.assertRedirects(response, reverse('pending-project-list'))
+        self.assertRedirects(response, reverse('home'))
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_ProjectCreate_no_login(self):

--- a/django_project/base/views/project.py
+++ b/django_project/base/views/project.py
@@ -186,7 +186,7 @@ class ProjectCreateView(LoginRequiredMixin, ProjectMixin, CreateView):
     template_name = 'project/create.html'
 
     def get_success_url(self):
-        return reverse('pending-project-list')
+        return reverse('home')
 
     def get_form_kwargs(self):
         kwargs = super(ProjectCreateView, self).get_form_kwargs()


### PR DESCRIPTION
fix #736 

Project is approved by default and redirect user to home after creation.
![peek 2018-03-30 05-55](https://user-images.githubusercontent.com/26101337/38117467-5eb82d64-33df-11e8-8655-20b93f3efbff.gif)
