### PR TITLE
fix print bug and convener slug duplicates

### DIFF
--- a/django_project/certification/models/course_convener.py
+++ b/django_project/certification/models/course_convener.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from core.settings.contrib import STOP_WORDS
 from unidecode import unidecode
 from certifying_organisation import CertifyingOrganisation
+from certification.utilities import check_slug
 
 
 class CourseConvener(models.Model):
@@ -60,7 +61,9 @@ class CourseConvener(models.Model):
         # unidecode() represents special characters (unicode data) in ASCII
         new_list = '%s-%s' % \
                    (self.user.username, unidecode(' '.join(filtered_words)))
-        self.slug = slugify(new_list)[:50]
+        new_slug = slugify(new_list)[:50]
+        new_slug = check_slug(CourseConvener.objects.all(), new_slug)
+        self.slug = slugify(new_slug)[:50]
         super(CourseConvener, self).save(*args, **kwargs)
 
     def __unicode__(self):

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -214,11 +214,15 @@ def generate_pdf(
 
     if course.course_convener.title:
         convener_name = \
-            '{} {}'.format(course.course_convener.title, convener_name)
+            '{} {}'.format(
+                course.course_convener.title.encode('utf-8'),
+                convener_name)
 
     if course.course_convener.degree:
         convener_name = \
-            '{}, {}'.format(convener_name, course.course_convener.degree)
+            '{}, {}'.format(
+                convener_name,
+                course.course_convener.degree.encode('utf-8'))
 
     course_duration = \
         'From {} {} {} to {} {} {}'.format(


### PR DESCRIPTION
fix #868 

This PR fixes:
- Error when printing using special characters
- Duplicate slug for course convener

Printed certificate that initially fails:
![screenshot from 2018-04-02 09-32-10](https://user-images.githubusercontent.com/26101337/38180940-4197dba8-365a-11e8-8cb7-9e9c525c2c45.png)
