### PR TITLE
fix string encoding

### DIFF
--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -151,14 +151,16 @@ class CertificateDetailView(DetailView):
             if certificate.course.course_convener.title:
                 convener_name = \
                     '{} {}'.format(
-                        certificate.course.course_convener.title,
+                        certificate.course.course_convener.title.encode(
+                            'utf-8'),
                         convener_name)
 
             if certificate.course.course_convener.degree:
                 convener_name = \
                     '{}, {}'.format(
                         convener_name,
-                        certificate.course.course_convener.degree)
+                        certificate.course.course_convener.degree.encode(
+                            'utf-8'))
 
             context['convener_name'] = convener_name
         context['project_slug'] = self.project_slug


### PR DESCRIPTION
fix #868 

Fixes encoding for convener title and degree on certificate details page.
![screenshot from 2018-04-03 17-32-37](https://user-images.githubusercontent.com/26101337/38244497-1276faaa-3765-11e8-9e8a-a511a2a0e001.png)
