### PR TITLE
tweak domain

### DIFF
--- a/django_project/core/custom_middleware.py
+++ b/django_project/core/custom_middleware.py
@@ -163,5 +163,5 @@ class CheckDomainMiddleware(object):
             else:
                 # for production the domain is hardcoded for consistency
                 return HttpResponseRedirect(
-                    'http://changelog.qgis.org/en/domain-not-found/'
+                    'http://changelog.kartoza.com/en/domain-not-found/'
                 )

--- a/django_project/core/settings/project.py
+++ b/django_project/core/settings/project.py
@@ -80,10 +80,5 @@ PIPELINE_CSS['project'] = {
 VALID_DOMAIN = [
     'localhost',
     '0.0.0.0',
-    'staging.projecta.kartoza.com',
-    'changelog.linfiniti.com',
     'changelog.kartoza.com',
-    'changelog.qgis.org',
-    'changelog.inasafe.org',
-    'staging.changelog.qgis.org'
 ]

--- a/django_project/core/tests/test_check_domain_middleware.py
+++ b/django_project/core/tests/test_check_domain_middleware.py
@@ -54,6 +54,6 @@ class TestCheckDomainMiddleware(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(
             response,
-            expected_url='http://changelog.qgis.org/en/domain-not-found/',
+            expected_url='http://changelog.kartoza.com/en/domain-not-found/',
             fetch_redirect_response=False,
         )


### PR DESCRIPTION
- Made `changelog.kartoza.com` as default site: where we can register domain.
- If we want to only show projects that belongs to kartoza, we can do that by registering `changelog.kartoza.com` for Kartoza organisation. After that the site should only showing the projects that belongs to Kartoza.