### PR TITLE
Sponsorship period changes

### DIFF
--- a/django_project/changes/templates/sponsorship_period/list.html
+++ b/django_project/changes/templates/sponsorship_period/list.html
@@ -27,7 +27,7 @@
                     {% if not unapproved %}
                         <a class="btn btn-default btn-mini tooltip-toggle"
                            href='{% url "pending-sponsorshipperiod-list" project_slug %}'
-                           data-title="View Pending sponsorship period">
+                           data-title="View Pending Sponsor entries">
                             <span class="glyphicon glyphicon-time"></span>
                         </a>
                     {% endif %}


### PR DESCRIPTION
fix #885 

- [x] Change tooltip from "View Pending sponsorship period" to "View Pending Sponsor entries".
