### PR TITLE
raise 404 when object does not exist

### DIFF
--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -271,8 +271,16 @@ class CertifyingOrganisationDetailView(
             slug = self.kwargs.get('slug', None)
             project_slug = self.kwargs.get('project_slug', None)
             if slug and project_slug:
-                project = Project.objects.get(slug=project_slug)
-                obj = queryset.get(project=project, slug=slug)
+                try:
+                    project = Project.objects.get(slug=project_slug)
+                except Project.DoesNotExist:
+                    raise Http404('Sorry! We could not find '
+                                  'your Project!')
+                try:
+                    obj = queryset.get(project=project, slug=slug)
+                except CertifyingOrganisation.DoesNotExist:
+                    raise Http404('Sorry! We could not find '
+                                  'your Certifying Organisation!')
                 return obj
             else:
                 raise Http404('Sorry! We could not find '


### PR DESCRIPTION
This PR:
- Raise 404 when project or certification is not found in the system.