### PR TITLE
fix sponsor form to check unique fields

### DIFF
--- a/django_project/changes/forms.py
+++ b/django_project/changes/forms.py
@@ -172,7 +172,8 @@ class SponsorForm(forms.ModelForm):
             'sponsor_email',
             'agreement',
             'logo',
-            'invoice_number'
+            'invoice_number',
+            'project',
         )
 
     def __init__(self, *args, **kwargs):
@@ -198,12 +199,13 @@ class SponsorForm(forms.ModelForm):
         self.helper.layout = layout
         self.helper.html5_required = False
         super(SponsorForm, self).__init__(*args, **kwargs)
+        self.fields['project'].initial = self.project
+        self.fields['project'].widget = forms.HiddenInput()
         self.helper.add_input(Submit('submit', 'Submit'))
 
     def save(self, commit=True):
         instance = super(SponsorForm, self).save(commit=False)
         instance.author = self.user
-        instance.project = self.project
         instance.approved = False
         instance.save()
         return instance


### PR DESCRIPTION
This PR fixes http://sentry.kartoza.com/sentry/projecta/issues/25/

It fixed the form to check the unique together relations `project` and `sponsor`

gif: when trying to add a new sponsor with the same name within a project
![peek 2018-04-20 16-22](https://user-images.githubusercontent.com/26101337/39043253-1dbc066c-44b7-11e8-94c6-21afc9e175ee.gif)
