### PR TITLE
fix unique together

### DIFF
--- a/django_project/certification/admin.py
+++ b/django_project/certification/admin.py
@@ -14,6 +14,10 @@ from certification.models.certifying_organisation import CertifyingOrganisation
 
 class CertificateAdmin(admin.ModelAdmin):
     """Certificate admin model."""
+
+    list_display = ('__unicode__', 'course')
+    search_fields = ('certificateID', 'course__name',)
+
     def queryset(self, request):
         """Ensure we use the correct manager.
 

--- a/django_project/certification/migrations/0019_auto_20180420_1205.py
+++ b/django_project/certification/migrations/0019_auto_20180420_1205.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('certification', '0018_auto_20180328_1302'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='certificate',
+            unique_together=set([('course', 'attendee')]),
+        ),
+    ]

--- a/django_project/certification/models/certificate.py
+++ b/django_project/certification/models/certificate.py
@@ -47,7 +47,7 @@ class Certificate(models.Model):
     class Meta:
         ordering = ['certificateID']
         unique_together = [
-            'course', 'attendee', 'certificateID',
+            'course', 'attendee',
         ]
 
     def __unicode__(self):


### PR DESCRIPTION
This PR fixes this http://sentry.kartoza.com/sentry/projecta/issues/123/ and http://sentry.kartoza.com/sentry/projecta/issues/125/

It fixes the unique together, that has caused there were duplicates in certificate. 
We also need to delete one of this certificate in database `QGIS-125` or `QGIS-126`. They are duplicates. They have the same attendee and course. I checked it on the course details page the attendee is no longer there. Maybe they have deleted the course attendee but the certificate remains.