### PR TITLE
reshape item descriptions

### DIFF
--- a/django_project/changes/feeds/sponsor.py
+++ b/django_project/changes/feeds/sponsor.py
@@ -3,6 +3,7 @@
 __author__ = 'Anita Hapsari <anita@kartoza.com>'
 __date__ = '23/10/2017'
 
+import datetime
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
 from django.utils.feedgenerator import Atom1Feed
@@ -79,8 +80,10 @@ class RssSponsorFeed(Feed):
         :returns: List of latest sponsor of a project
         :rtype: list
         """
+        today = datetime.datetime.now().date()
         return SponsorshipPeriod.objects.filter(
-            project=obj).order_by('-sponsorship_level__value', '-end_date')
+            project=obj, end_date__gte=today
+        ).order_by('-sponsorship_level__value', '-end_date')
 
     def item_title(self, item):
         """Return the title of the sponsor.

--- a/django_project/changes/feeds/sponsor.py
+++ b/django_project/changes/feeds/sponsor.py
@@ -3,8 +3,8 @@
 __author__ = 'Anita Hapsari <anita@kartoza.com>'
 __date__ = '23/10/2017'
 
-from django.conf import settings
 from django.contrib.syndication.views import Feed
+from django.core.urlresolvers import reverse
 from django.utils.feedgenerator import Atom1Feed
 from django.shortcuts import get_object_or_404
 from base.models.project import Project
@@ -34,6 +34,7 @@ class RssSponsorFeed(Feed):
         :raises: Http404
         """
         project_slug = kwargs.get('project_slug', None)
+        self.domain_path_url = request.build_absolute_uri(reverse('home'))
         return get_object_or_404(Project, slug=project_slug)
 
     def title(self, obj):
@@ -101,20 +102,26 @@ class RssSponsorFeed(Feed):
         :returns: description of the sponsor
         :rtype: str
         """
+        level_class = str(item.sponsorship_level.name).decode('utf-8').lower()
+        head, sep, tail = self.domain_path_url.partition('/en/')
+
         data = {
-            'media_url': settings.MEDIA_URL,
-            'sponsor_logo': item.sponsor.logo,
+            'domain': head,
+            'sponsor_logo': item.sponsor.logo.url,
             'sponsor_level': item.sponsorship_level,
             'start_date': item.start_date.strftime('%d %B %Y'),
             'end_date': item.end_date.strftime('%d %B %Y'),
             'currency': item.currency,
             'amount_sponsored': item.amount_sponsored,
+            'sponsor_class': level_class,
         }
 
         descriptions = \
             '<div>' \
-            '<img src="{media_url}{sponsor_logo}" width="300px"></div>' \
-            '<p><span>Sponsorship level: {sponsor_level}</span><br/>' \
+            '<img class="sponsor_img {sponsor_class}" ' \
+            'src="{domain}{sponsor_logo}" width="300px"></div>' \
+            '<p class="sponsor_body {sponsor_class}">' \
+            '<span>Sponsorship level: {sponsor_level}</span><br/>' \
             '<span>Sponsorship period: {start_date} - {end_date}</span><br/>' \
             '<span>Amount sponsored: {currency} {amount_sponsored}<span></p>'\
             .format(**data)


### PR DESCRIPTION
fix #904 

Item descriptions:
- [x] `<img>` tag has `sponsor_img` class and its url is full url. (in the example below using my local machine)
- [x] `<p>` tag has `sponsor_body` class
- [x] the `<img>` and `<p>` tag have class name based on the sponsorship level name, e.g. gold, bronze, etc. 

example result:
```
<div>
<img class="sponsor_img gold" src="http://0.0.0.0:61202/media/images/projects/b9c08a00a74cba8e406e97f94a1f90595f5ac39d.png" width="300px">
</div>

<p class="sponsor_body gold">
<span>Sponsorship level: Gold : 9000 EUR</span><br/>
<span>Sponsorship period: 21 June 2017 - 21 June 2018</span><br/>
<span>Amount sponsored: EUR 9000.00<span>
</p>
```