### PR TITLE
fix increment certificate ID

### DIFF
--- a/django_project/certification/models/certificate.py
+++ b/django_project/certification/models/certificate.py
@@ -17,10 +17,19 @@ def increment_id(project):
     last_certificate = Certificate.objects.filter(
         course__certifying_organisation__project=project
     ).count()
+
     if last_certificate == 0:
         return '1'
-    last_int_id = last_certificate
-    new_int_id = last_int_id + 1
+
+    # get the latest certificate ID within a project
+    latest_certificate = Certificate.objects.filter(
+        course__certifying_organisation__project=project).latest('int_id')
+    words = '{}-'.format(project.name)
+    latest_certificate_number = str(latest_certificate.certificateID).replace(
+        words, "")
+    latest_certificate_number = int(latest_certificate_number)
+    new_int_id = latest_certificate_number + 1
+
     return new_int_id
 
 

--- a/django_project/certification/models/certificate.py
+++ b/django_project/certification/models/certificate.py
@@ -24,7 +24,7 @@ def increment_id(project):
     # get the latest certificate ID within a project
     latest_certificate = Certificate.objects.filter(
         course__certifying_organisation__project=project).latest('int_id')
-    words = '{}-'.format(project.name)
+    words = '{}-'.format(str(project.name).replace(' ', ''))
     latest_certificate_number = str(latest_certificate.certificateID).replace(
         words, "")
     latest_certificate_number = int(latest_certificate_number)


### PR DESCRIPTION
Fix sentry issue: http://sentry.kartoza.com/sentry/projecta/issues/147/

Previously the certificate ID is incremented by counting the number of certificate within a project. This causes a problem that is certificate ID duplicates when we removed existing certificates.
The new increment ID system is looking at the latest certificate ID then increment it.

Example case:
Current certificate id is `QGIS-135` (the number of certificates in QGIS project is 135). Then we removes certificate with id `QGIS-127`. Thus the number of certificates in QGIS project is 134 but the latest certificate ID is QGIS-135.

Using old increment ID system:
Since the number of certificates in QGIS is 134, the new certificate is QGIS-135 (cause duplicate ID).

e.g. using new increment ID system:
Since it looks at the latest ID, so the new certificate is QGIS-136

PS: for the existing certificate that has duplicate ID in the database, maybe we need to manually remove it then issue a new one.