### PR TITLE
add edit attendee view

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -414,6 +414,45 @@ class AttendeeForm(forms.ModelForm):
         return instance
 
 
+class UpdateAttendeeForm(forms.ModelForm):
+
+    class Meta:
+        model = Attendee
+        fields = (
+            'firstname',
+            'surname',
+            'email',
+            'certifying_organisation',
+        )
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user')
+        self.certifying_organisation = kwargs.pop('certifying_organisation')
+        form_title = 'Update Attendee'
+        self.helper = FormHelper()
+        layout = Layout(
+            Fieldset(
+                form_title,
+                Field('firstname', css_class='form-control'),
+                Field('surname', css_class='form-control'),
+                Field('email', css_class='form-control'),
+            )
+        )
+        self.helper.layout = layout
+        self.helper.html5_required = False
+        super(UpdateAttendeeForm, self).__init__(*args, **kwargs)
+        self.fields['certifying_organisation'].initial = \
+            self.certifying_organisation
+        self.fields['certifying_organisation'].widget = forms.HiddenInput()
+        self.helper.add_input(Submit('submit', 'Add'))
+
+    def save(self, commit=True):
+        instance = super(UpdateAttendeeForm, self).save(commit=False)
+        instance.author = self.user
+        instance.save()
+        return instance
+
+
 class CertificateForm(forms.ModelForm):
 
     class Meta:

--- a/django_project/certification/models/course.py
+++ b/django_project/certification/models/course.py
@@ -3,6 +3,7 @@
 
 """
 
+import datetime
 import os
 from django.conf.global_settings import MEDIA_ROOT
 from django.urls import reverse
@@ -134,3 +135,12 @@ class Course(models.Model):
             'organisation_slug': self.certifying_organisation.slug,
             'project_slug': self.certifying_organisation.project.slug
         })
+
+    @property
+    def editable(self):
+        today = datetime.datetime.today().date()
+        delta = self.end_date + datetime.timedelta(days=7)
+        if today > delta:
+            return False
+        else:
+            return True

--- a/django_project/certification/templates/attendee/update.html
+++ b/django_project/certification/templates/attendee/update.html
@@ -1,0 +1,23 @@
+{% extends "project_base.html" %}
+{% load staticfiles %}
+{% load crispy_forms_tags %}
+
+{% block page_title %}
+    <h1>Update Attendee</h1>
+{% endblock page_title %}
+
+{% block content %}
+    <section id="forms">
+        <div class='container'>
+            <form method="post" enctype="multipart/form-data">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <div class="vertical-space"></div>
+                <div class="form-actions">
+                    <input type="submit" name="submit" value="Submit"
+                           class="btn btn-primary" id="submit-save">
+                </div>
+            </form>
+        </div>
+    </section>
+{% endblock %}

--- a/django_project/certification/templates/course/detail.html
+++ b/django_project/certification/templates/course/detail.html
@@ -207,6 +207,19 @@
                 {% if user in course.certifying_organisation.organisation_owners.all or user.is_staff or user == course.course_convener.user or user == project.owner or user in course.certifying_organisation.project.certification_managers.all %}
                 <td  style="text-align: center">
                     <div class="btn-group pull-right">
+                        {% if course.editable %}
+                            <a class="btn btn-default btn-xs btn-print tooltip-toggle"
+                                href='{% url "attendee-update" project_slug=course.certifying_organisation.project.slug organisation_slug=course.certifying_organisation.slug course_slug=course.slug pk=attendee.attendee.pk %}'
+                                data-title="Edit Attendee">
+                                <span class="glyphicon glyphicon-pencil"></span>
+                            </a>
+                        {% else %}
+                            <a class="btn btn-default btn-xs btn-print tooltip-toggle" disabled
+                                href='#'
+                                data-title="Edit attendee only available until 7 days after the course ends.">
+                                <span class="glyphicon glyphicon-pencil"></span>
+                            </a>
+                        {% endif %}
                         {% if attendee.attendee.pk in certificates %}
                             {% if attendee.attendee.pk in paid_certificates %}
                                 <a class="btn btn-default btn-xs btn-print tooltip-toggle"

--- a/django_project/certification/urls.py
+++ b/django_project/certification/urls.py
@@ -40,6 +40,7 @@ from .views import (
     # Attendee.
     AttendeeCreateView,
     CsvUploadView,
+    AttendeeUpdateView,
 
     # Course Attendee.
     CourseAttendeeCreateView,
@@ -192,6 +193,11 @@ urlpatterns = [
               '(?P<slug>[\w-]+)/create-attendee/$',
         view=AttendeeCreateView.as_view(),
         name='attendee-create'),
+    url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
+              '(?P<organisation_slug>[\w-]+)/course/'
+              '(?P<course_slug>[\w-]+)/attendee/(?P<pk>[\w-]+)/update/$',
+        view=AttendeeUpdateView.as_view(),
+        name='attendee-update'),
 
     url(regex='^(?P<project_slug>[\w-]+)/certifyingorganisation/'
               '(?P<organisation_slug>[\w-]+)/course/'

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -4,12 +4,13 @@ import csv
 from django.db import transaction
 from django.urls import reverse
 from django.views.generic import (
-    CreateView, FormView)
+    CreateView, FormView, UpdateView)
 from braces.views import LoginRequiredMixin, FormMessagesMixin
 from certification.models import (
     Attendee, CertifyingOrganisation, CourseAttendee, Course
 )
-from certification.forms import AttendeeForm, CsvAttendeeForm
+from certification.forms import (
+    AttendeeForm, CsvAttendeeForm, UpdateAttendeeForm)
 
 
 class AttendeeMixin(object):
@@ -240,3 +241,61 @@ class CsvUploadView(FormMessagesMixin, LoginRequiredMixin, FormView):
 
         else:
             return self.form_invalid(form)
+
+
+class AttendeeUpdateView(LoginRequiredMixin, UpdateView):
+    """View for updating attendee."""
+
+    context_object_name = 'attendee'
+    template_name = 'attendee/update.html'
+    model = Attendee
+    form_class = UpdateAttendeeForm
+
+    def get_success_url(self):
+        """Define the redirect URL.
+
+        After successful updating the object, the User will be redirected
+        to the course detail page.
+
+       :returns: URL
+       :rtype: HttpResponse
+       """
+
+        return reverse('course-detail', kwargs={
+                'project_slug': self.project_slug,
+                'organisation_slug': self.organisation_slug,
+                'slug': self.course_slug,
+            })
+
+    def get_context_data(self, **kwargs):
+        """Get the context data which is passed to a template.
+
+        :param kwargs: Any arguments to pass to the superclass.
+        :type kwargs: dict
+
+        :returns: Context data which will be passed to the template.
+        :rtype: dict
+        """
+
+        context = super(
+            AttendeeUpdateView, self).get_context_data(**kwargs)
+        return context
+
+    def get_form_kwargs(self):
+        """Get keyword arguments from form.
+
+        :returns keyword argument from the form
+        :rtype: dict
+        """
+
+        kwargs = super(AttendeeUpdateView, self).get_form_kwargs()
+        self.project_slug = self.kwargs.get('project_slug', None)
+        self.organisation_slug = self.kwargs.get('organisation_slug', None)
+        self.course_slug = self.kwargs.get('course_slug', None)
+        self.certifying_organisation = \
+            CertifyingOrganisation.objects.get(slug=self.organisation_slug)
+        kwargs.update({
+            'user': self.request.user,
+            'certifying_organisation': self.certifying_organisation
+        })
+        return kwargs

--- a/django_project/certification/views/attendee.py
+++ b/django_project/certification/views/attendee.py
@@ -262,10 +262,10 @@ class AttendeeUpdateView(LoginRequiredMixin, UpdateView):
        """
 
         return reverse('course-detail', kwargs={
-                'project_slug': self.project_slug,
-                'organisation_slug': self.organisation_slug,
-                'slug': self.course_slug,
-            })
+            'project_slug': self.project_slug,
+            'organisation_slug': self.organisation_slug,
+            'slug': self.course_slug,
+        })
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template.


### PR DESCRIPTION
Fix #1169 

This PR:
- [x] Add view to update Attendee
- [x] Made button available only until 7 days after the course ends

When editing attendee:
- User is able to edit the attendee info
- Certificate is not updated automatically so when the certificate is already generated, user needs to regenerate its certificate.
![Peek 2020-07-29 11-35](https://user-images.githubusercontent.com/26101337/88757433-356c3080-d190-11ea-9ce4-c60e799c7bfa.gif)

Button only available until 7 days after the course ends
![Peek 2020-07-29 11-37](https://user-images.githubusercontent.com/26101337/88757436-369d5d80-d190-11ea-92b0-b0f4ddd2892a.gif)
