### PR TITLE
fix github label arrangement on import form

### DIFF
--- a/django_project/changes/templates/version/includes/github-form-modal.html
+++ b/django_project/changes/templates/version/includes/github-form-modal.html
@@ -3,9 +3,11 @@
         border: 1px solid lightgrey;
         border-radius: 3px;
         margin-right: 5px;
-        padding: 6px 7px 3px 7px;
+        padding: 3px 7px 3px 7px;
         white-space: nowrap;
-        line-height: 23px;
+        line-height: 10px;
+        display: inline-block;
+        margin-bottom: 7px
     }
     .label-github {
         max-height: 200px;


### PR DESCRIPTION
fix #1137 

![Screenshot from 2020-07-29 12-03-02](https://user-images.githubusercontent.com/26101337/88758877-bda00500-d193-11ea-81a8-4405e8031f35.png)
