### PR TITLE
fix test, class inheritance DjangoModelFactory

### DIFF
--- a/django_project/core/model_factories.py
+++ b/django_project/core/model_factories.py
@@ -10,7 +10,7 @@ if DJANGO_VERSION[:2] >= (1, 4):
 
 
 # noinspection PyProtectedMember
-class UserF(factory.DjangoModelFactory):
+class UserF(factory.django.DjangoModelFactory):
 
     class Meta:
         model = User

--- a/django_project/vota/tests/model_factories.py
+++ b/django_project/vota/tests/model_factories.py
@@ -7,7 +7,7 @@ from vota.models.vote import Vote
 from core.model_factories import UserF
 
 
-class BallotF(factory.DjangoModelFactory):
+class BallotF(factory.django.DjangoModelFactory):
     """
     Ballot model factory
     """
@@ -27,7 +27,7 @@ class BallotF(factory.DjangoModelFactory):
     committee = factory.SubFactory('vota.tests.model_factories.CommitteeF')
 
 
-class CommitteeF(factory.DjangoModelFactory):
+class CommitteeF(factory.django.DjangoModelFactory):
     """
     Committee model factory
     """
@@ -53,7 +53,7 @@ class CommitteeF(factory.DjangoModelFactory):
                 self.users.add(user)
 
 
-class VoteF(factory.DjangoModelFactory):
+class VoteF(factory.django.DjangoModelFactory):
     """
     Vote model factory
     """


### PR DESCRIPTION
@timlinux 

**background:**
There was error https://travis-ci.org/github/kartoza/prj.app/builds/733263015 in https://github.com/kartoza/prj.app/pull/1218#issuecomment-704187885 during `coverage run manage.py test`
<img width="1032" alt="Screenshot 2020-10-12 at 7 43 24 AM" src="https://user-images.githubusercontent.com/40058076/95693412-cebec500-0c5e-11eb-91a8-34e1aa7e4f54.png">

**What does this PR do:**
The error raised from class inheritance of DjangoModelFactory, this PR change the parent class in class inheritance from `factory.DjangoModelFactory` to `factory.django.DjangoModelFactory`. 
Running this test locally:
<img width="801" alt="Screenshot 2020-10-12 at 7 13 42 AM" src="https://user-images.githubusercontent.com/40058076/95693639-f5313000-0c5f-11eb-9601-207b0ab8db78.png">

