### PR TITLE
assigned value to release_date attribute on save method

### DIFF
--- a/django_project/changes/forms.py
+++ b/django_project/changes/forms.py
@@ -97,7 +97,10 @@ class VersionForm(forms.ModelForm):
 
     def save(self, commit=True):
         instance = super(VersionForm, self).save(commit=False)
-        version = Version.objects.get(pk=instance.pk)
+        try:
+            version = Version.objects.get(pk=instance.pk)
+        except Version.DoesNotExist:
+            version = None
         if version:
             instance.release_date = version.release_date
         instance.author = self.user

--- a/django_project/changes/forms.py
+++ b/django_project/changes/forms.py
@@ -97,6 +97,9 @@ class VersionForm(forms.ModelForm):
 
     def save(self, commit=True):
         instance = super(VersionForm, self).save(commit=False)
+        version = Version.objects.get(pk=instance.pk)
+        if version:
+            instance.release_date = version.release_date
         instance.author = self.user
         instance.project = self.project
         instance.approved = False


### PR DESCRIPTION
@timlinux 

This PR is referring to issue #1216 and https://github.com/kartoza/prj.app/issues/1216#issuecomment-704254144

**What does this PR do:**
This PR assigns the value of `release_date` attribute in modelForm when the instance invoking `save()` method, so that if it edits the version in the frontend editor, it will preserve the date.

_**gif image:**_
![projecta_1216](https://user-images.githubusercontent.com/40058076/95697613-e6537900-0c71-11eb-9129-b538feab6389.gif)
