### PR TITLE
GitHub - Parse the content to find the "funded by" and its URL

### DIFF
--- a/django_project/changes/tests/test_github_pull_request.py
+++ b/django_project/changes/tests/test_github_pull_request.py
@@ -1,0 +1,88 @@
+""" Tests about the GitHub harvesting. """
+
+import unittest
+
+from changes.utils.github_pull_request import parse_funded_by
+
+
+class TestGithubPullRequest(unittest.TestCase):
+
+    def test_funded_by(self):
+        """ Test to parse the PR content and find the funded by. """
+        # Normal, with my name in capital letters, HTTP
+        body = (
+            'This is a new feature\n'
+            'Funded by I\'am AWESOME http://myself.me'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This is a new feature', content)
+        self.assertEqual('I\'am AWESOME', funded_by)
+        self.assertEqual('http://myself.me', url)
+
+        # In the middle of the PR content, no URL
+        body = (
+            'This \n'
+            'is a new feature\n'
+            'Funded by myself.inc\n'
+            'It will rock !'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This \nis a new feature\nIt will rock !', content)
+        self.assertEqual('myself.inc', funded_by)
+        self.assertEqual('', url)
+
+        # No funded by
+        body = (
+            'This \n'
+            'is a new feature\n'
+            'It will rock !'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This \nis a new feature\nIt will rock !', content)
+        self.assertEqual('', funded_by)
+        self.assertEqual('', url)
+
+        # With spaces/tab and upper/lower case, HTTPS
+        body = (
+            'This is a new feature\n'
+            '   funded BY   myself.inc  https://myself.me'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This is a new feature', content)
+        self.assertEqual('myself.inc', funded_by)
+        self.assertEqual('https://myself.me', url)
+
+        # With markdown and two \n
+        body = (
+            'This is a new feature :\n\n'
+            '* Funded by myself.inc https://myself.me\n'
+            '* IT\n'
+            '* WILL\n'
+            '* ROCK'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual(
+            'This is a new feature :\n\n* IT\n* WILL\n* ROCK', content)
+        self.assertEqual('myself.inc', funded_by)
+        self.assertEqual('https://myself.me', url)
+
+        # No name, only URL
+        body = (
+            'This is a new feature :\n'
+            '* Funded by https://myself.me\n'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This is a new feature :\n', content)
+        self.assertEqual('', funded_by)
+        self.assertEqual('https://myself.me', url)
+
+        # No name, no URL, but with "funded by"
+        body = (
+            'This is a new feature :\n'
+            '* Funded by\n'
+            '* Another line'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual('This is a new feature :\n* Another line', content)
+        self.assertEqual('', funded_by)
+        self.assertEqual('', url)

--- a/django_project/changes/utils/github_pull_request.py
+++ b/django_project/changes/utils/github_pull_request.py
@@ -1,0 +1,48 @@
+""" Tools for parsing the GitHub pull request. """
+
+import re
+
+
+def parse_funded_by(content: str) -> tuple:
+    """ Parse the pull request content and find a 'funded by'.
+
+    It returns the content but without the funder in it if was found.
+    """
+    token = 'funded by'
+    funded_regex = r'^{}'.format(token)
+    url_regex = r'(https?://\S+)'
+
+    new_content = []
+    funded_by = ''
+    funded_by_url = ''
+
+    # noinspection PyBroadException
+    try:
+        lines = content.split('\n')
+        for line in lines:
+
+            # If it starts by a markdown bullet list
+            cleaned = line.lstrip('* ').strip()
+            if cleaned.lower().startswith(token):
+
+                # Remove the "funded by"
+                cleaned = re.sub(
+                    funded_regex, '', cleaned, flags=re.IGNORECASE)
+
+                # Look for URL
+                urls = re.findall(url_regex, cleaned)
+                if urls:
+                    funded_by_url = urls[0]
+
+                # Remove the URL
+                funder = re.sub(url_regex, '', cleaned)
+                funded_by = funder.strip()
+            else:
+                new_content.append(line)
+
+        content = '\n'.join(new_content)
+        return content, funded_by, funded_by_url
+
+    except Exception:
+        # Let's be safe
+        return content, '', ''

--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -14,6 +14,7 @@ from base.models.project import Project
 from changes.models.category import Category
 from changes.models.entry import Entry
 from changes.models.version import Version
+from changes.utils.github_pull_request import parse_funded_by
 
 try:
     from core.settings.secret import GIT_TOKEN
@@ -40,14 +41,18 @@ def create_entry_from_github_pr(version, category, data, user):
             if not name:
                 name = response.json()['login']
 
+        content, funded_by, funded_by_url = parse_funded_by(item['body'])
+
         if item['html_url'] not in existing_entries:
             # Create new entry from data.
             Entry.objects.create(
                 category=category,
                 title=item['title'],
-                description=item['body'],
+                description=content,
                 developer_url=item['user']['url'],
                 developed_by=name,
+                funded_by=funded_by,
+                funded_by_url=funded_by_url,
                 author=user,
                 version=version,
                 github_PR_url=item['html_url']


### PR DESCRIPTION
In a pull request, I'm trying to parse and find the funder when harvesting the PR.

For instance : https://github.com/3liz/lizmap-web-client/pull/1823

Funded by XXX URL

I just did that with my unittest, I will try to give it a try on my local.

CC @zacharlie @sumandari @timlinux 