### PR TITLE
modify test_Entry_read for developer_info_html output

### DIFF
--- a/django_project/changes/tests/test_models.py
+++ b/django_project/changes/tests/test_models.py
@@ -103,11 +103,31 @@ class TestEntryCRUD(TestCase):
         Tests Entry model read
         """
         model = EntryF.create(
-            title=u'Custom Entry'
+            title=u'Custom Entry',
+            developed_by=u'Tim'
         )
 
         self.assertTrue(model.title == 'Custom Entry')
         self.assertTrue(model.slug == 'custom-entry')
+        self.assertTrue(model.developer_info_html() == '')
+
+        model = EntryF.create(
+            title=u'Custom Entry',
+            developed_by=u'Tim',
+            developer_url=''
+        )
+        self.assertTrue(
+            model.developer_info_html() == 'This feature was '
+                                        'developed by Tim ')
+
+        model = EntryF.create(
+            title=u'Custom Entry',
+            developed_by=u'Tim',
+            developer_url=u'https://github.com/timlinux'
+        )
+        self.assertTrue(
+            model.developer_info_html() == 'This feature was '
+            'developed by [Tim](https://github.com/timlinux)')
 
     def test_Entry_update(self):
         """

--- a/django_project/changes/tests/test_models.py
+++ b/django_project/changes/tests/test_models.py
@@ -118,7 +118,7 @@ class TestEntryCRUD(TestCase):
         )
         self.assertTrue(
             model.developer_info_html() == 'This feature was '
-                                        'developed by Tim ')
+                                           'developed by Tim ')
 
         model = EntryF.create(
             title=u'Custom Entry',
@@ -127,7 +127,8 @@ class TestEntryCRUD(TestCase):
         )
         self.assertTrue(
             model.developer_info_html() == 'This feature was '
-            'developed by [Tim](https://github.com/timlinux)')
+                                           'developed by [Tim]'
+                                           '(https://github.com/timlinux)')
 
     def test_Entry_update(self):
         """


### PR DESCRIPTION
@timlinux 

according to issue #1069, this PR adds test to ensure that the developer_info_html method gives the correct output.

I have run the test on local machine, and the result is OK

```
zoommbp:~ zoom$ docker exec projecta-dev-web ./manage.py test changes.tests.test_models.TestEntryCRUD.test_Entry_read
Creating test database for alias 'default'...
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField CertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:13:44.674507) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField CertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:15:14.131955) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField HistoricalCertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:13:44.674507) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField HistoricalCertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:15:14.131955) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField CertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:15:25.358533) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField HistoricalCertifyingOrganisationCertificate.issued received a naive datetime (2019-12-04 05:15:25.358533) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField CertifyingOrganisationCertificate.issued received a naive datetime (2020-10-19 03:13:31.329600) while time zone support is active.
  RuntimeWarning)
/usr/local/lib/python3.7/site-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField HistoricalCertifyingOrganisationCertificate.issued received a naive datetime (2020-10-19 03:13:31.368727) while time zone support is active.
  RuntimeWarning)
.
----------------------------------------------------------------------
Ran 1 test in 0.122s

OK
Destroying test database for alias 'default'...
```