### PR TITLE
Change object references in module question answer

### DIFF
--- a/django_project/lesson/models/answer.py
+++ b/django_project/lesson/models/answer.py
@@ -84,5 +84,8 @@ class Answer(TranslationMixin):
     def __unicode__(self):
         return self.answer
 
+    def __str__(self):
+        return self.answer
+
 
 from lesson.signals.answer import *  # noqa

--- a/django_project/lesson/models/section.py
+++ b/django_project/lesson/models/section.py
@@ -95,5 +95,8 @@ class Section(TranslationMixin):
     def __unicode__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
 
 from lesson.signals.section import *  # noqa

--- a/django_project/lesson/models/specification.py
+++ b/django_project/lesson/models/specification.py
@@ -85,5 +85,8 @@ class Specification(TranslationMixin):
     def __unicode__(self):
         return self.title
 
+    def __str__(self):
+        return self.title
+
 
 from lesson.signals.specification import *  # noqa

--- a/django_project/lesson/models/worksheet.py
+++ b/django_project/lesson/models/worksheet.py
@@ -185,4 +185,7 @@ class Worksheet(TranslationMixin):
     def __unicode__(self):
         return self.module
 
+    def __str__(self):
+        return self.module
+
 from lesson.signals.worksheet import *  # noqa

--- a/django_project/lesson/models/worksheet_question.py
+++ b/django_project/lesson/models/worksheet_question.py
@@ -79,5 +79,8 @@ class WorksheetQuestion(TranslationMixin):
     def __unicode__(self):
         return self.question
 
+    def __str__(self):
+        return self.question
+
 
 from lesson.signals.worksheet_question import *  # noqa

--- a/django_project/lesson/tests/test_section_model.py
+++ b/django_project/lesson/tests/test_section_model.py
@@ -26,6 +26,9 @@ class TestSection(TestCase):
         # check if model name exists.
         self.assertTrue(model.name is not None)
 
+        # check if __str__ method returns the correct value
+        self.assertEqual(str(model), model.name)
+
     def test_Section_delete(self):
         """Test section model deletion."""
 

--- a/django_project/lesson/tests/test_specification_model.py
+++ b/django_project/lesson/tests/test_specification_model.py
@@ -26,6 +26,9 @@ class TestSpecification(TestCase):
         # check if model title exists.
         self.assertTrue(model.title is not None)
 
+        # check if __str__ method returns the correct value
+        self.assertEqual(str(model), model.title)
+
     def test_Specification_delete(self):
         """Test specification model deletion."""
 

--- a/django_project/lesson/tests/test_worksheet_model.py
+++ b/django_project/lesson/tests/test_worksheet_model.py
@@ -21,6 +21,9 @@ class TestSection(TestCase):
         # check if model title exists.
         self.assertTrue(model.title is not None)
 
+        # check if __str__ method returns the correct value
+        self.assertEqual(str(model), model.module)
+
     def test_Worksheet_delete(self):
         """Test worksheet model deletion."""
 

--- a/django_project/lesson/tests/test_worksheet_views.py
+++ b/django_project/lesson/tests/test_worksheet_views.py
@@ -135,10 +135,17 @@ class TestViews(TestCase):
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_WorksheetModuleQuestionAnswers(self):
+        """Test accessing module question answer"""
 
+        self.test_project.name = 'Test Question Answer'
+        self.test_project.save()
+        self.test_worksheet.module = 'Test Module Question Answer'
+        self.test_worksheet.save()
         response = self.client.get(reverse('worksheet-module-answers',
                                            kwargs=self.kwargs_worksheet_full))
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Test Question Answer')
+        self.assertContains(response, 'Test Module Question Answer')
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_WorksheetPrintView(self):


### PR DESCRIPTION
Hi @zacharlie 
This PR refers to #1237. It does:
- fix object references in question answers page

![0 0 0 0_61202_en_geonode_section_geonode-28_answers_28_](https://user-images.githubusercontent.com/40058076/102960002-e9919d80-451b-11eb-8c5f-cedf25522b13.png)
