### PR TITLE
Set encoding utf-8 in lesson pdf output

### DIFF
--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -4,6 +4,7 @@
 
 <html>
 <head>
+    <meta charset="UTF-8">
     <style>
 .icon-project-color {
     background-color: {{ worksheet.section.project.accent_color }};


### PR DESCRIPTION
@NyakudyaA @zacharlie 
This PR refers to #1246. It specifies the character encoding with value "UTF-8"
![1246_set_encoding](https://user-images.githubusercontent.com/40058076/102965999-f0bfa800-4529-11eb-8788-37a01ea67df8.png)

