### PR TITLE
always enable create further reading

### DIFF
--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -380,24 +380,23 @@
                           </strong>
                       </h3>
                     </div>
-           {% else %}
+           {% endif %}
+           {% if user_can_edit %}
                 <div class="col-lg-3 pull-right">
-                    {% if user_can_edit %}
-                        <div class="pull-right btn-group further-reading-action" style="display:none;">
-                            <a class="btn btn-default btn-mini tooltip-toggle"
-                               href='{% url "further-reading-create" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug worksheet_slug=worksheet.slug %}'
-                               data-title="{% trans 'Create New Further Reading Item' %}">
-                                {% show_button_icon "add" %}
-                            </a>
-                        </div>
-                    {% endif %}
+                    <div class="pull-right btn-group further-reading-action" style="display:none;">
+                        <a class="btn btn-default btn-mini tooltip-toggle"
+                           href='{% url "further-reading-create" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug worksheet_slug=worksheet.slug %}'
+                           data-title="{% trans 'Create New Further Reading Item' %}">
+                            {% show_button_icon "add" %}
+                        </a>
+                    </div>
                 </div>
            {% endif %}
         </div>
         <div class="row details-worksheet further-reading" style="margin-top:10px;">
             <div class="details-worksheet col-lg-12" style="margin-bottom: 20px">
                 <ul>
-                    {% for info in further_reading %}
+                    {% for info in further_reading reversed %}
                         <li style="list-style: none;">
                             <div class="row">
                                 {{ info.text }}


### PR DESCRIPTION
This PR refers to #1234. It does:
- always enable create new further reading 
- reverse the order of further reading item

![changelog_1235_lesson_further_reading](https://user-images.githubusercontent.com/40058076/103072558-bffe7200-4600-11eb-977c-5cd157c0e8d4.gif)


