### PR TITLE
enable smart download

### DIFF
--- a/django_project/lesson/templates/section/includes/row-worksheet.html
+++ b/django_project/lesson/templates/section/includes/row-worksheet.html
@@ -13,11 +13,13 @@
 
     <div class="col-lg-3">
         <div class="btn-group pull-right">
+            {% if worksheet.external_data %}
             <a id="download-pdf-button" class="btn btn-default btn-mini tooltip-toggle" target="_blank"
                href='{% url "worksheet-zip" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}'
                data-title="Download {{ worksheet.module }} module and its sample data as ZIP">
                 <span class="fa fa-download"></span>
             </a>
+            {% endif %}
             <a id="download-pdf-button" class="btn btn-default btn-mini tooltip-toggle" target="_blank"
                href='{% url "worksheet-print" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ forloop.parentloop.counter|add:page_obj.start_index|add:'-1' }}.{{ forloop.counter }}'
                data-title="Download {{ worksheet.module }} as PDF">

--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -429,7 +429,7 @@
             <div class="col-lg-12 text-center" style="margin-bottom: 10px;">
                 {% if worksheet.external_data %}
                 <p>
-                    {% blocktrans with url=worksheet.external_data.url %}Click <a target="_blank" href="{{ url }}" download="{{ file_title }}">here</a> to download the sample data for the lesson.{% endblocktrans %}
+                    {% blocktrans with url=worksheet.external_data.url %}<a target="_blank" href="{{ url }}" download="{{ file_title }}">Download the sample data</a> for the lesson.{% endblocktrans %}
                 </p>
                 {% endif %}
             </div>

--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -244,10 +244,10 @@ h2{
 {% endif %}
 
 <footer>
-        <div style="margin-bottom: 10px;padding-left: 100pt; padding-top: 10pt;">
+        <div style="margin-bottom: 10px;padding-top: 10pt;">
             {% if worksheet.external_data %}
                 <p>
-                    {% blocktrans with url=worksheet.external_data.url href_value=request.META.HTTP_HOST %}Click <a target="_blank" href="http://{{ href_value }}{{ url }}">here</a> to download the sample data for the lesson.{% endblocktrans %}
+                    {% blocktrans with url=worksheet.external_data.url href_value=request.META.HTTP_HOST %}Download the sample data for the lesson from <a target="_blank" href="http://{{ href_value }}{{ url }}">http://{{ href_value }}{{ url }}</a>.{% endblocktrans %}
                 </p>
             {% endif %}
         </div>


### PR DESCRIPTION
This PR refers to #1243. It does:
- only show the Download data options if the worksheets contain a zip file.
- change link download sample data description on web view and pdf

---
#### Download data options 

![1243_enable_smart_download_0](https://user-images.githubusercontent.com/40058076/103113136-53cd4e00-4694-11eb-8801-e1f318831b35.png)

---
#### Web view

![1243_enable_smart_download_1](https://user-images.githubusercontent.com/40058076/103113138-55971180-4694-11eb-86eb-0363322b61b7.png)

---
#### PDF

![1243_enable_smart_download_2](https://user-images.githubusercontent.com/40058076/103113140-56c83e80-4694-11eb-9a27-d27aeabbfe61.png)
