### PR TITLE
enhance pdf output

### DIFF
--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -290,7 +290,7 @@
                         <div class="row">
                             <li style="margin-bottom: 20px">
                                 <div class="col-lg-10">
-                                  <strong>{{ question.question }}:</strong>{{ question|is_translation_up_to_date }}
+                                  <p><strong>{{ question.question }}:</strong>{{ question|is_translation_up_to_date }}</p>
                                     {% if question.question_image %}
                                         <img id="{{ question.question_image }}"
                                              class="img-responsive img-rounded pull-left"
@@ -370,7 +370,7 @@
            {% if further_reading %}
                 <div class="col-lg-1">
                   <div class="pull-left" style="background-color:{{ worksheet.section.project.accent_color }}; height:50px;width:50px; margin-left:-15px;">
-                      <span class="glyphicon glyphicon-list-alt fa-3x" style="color:white"></span>
+                    <img src="{% static "img/book.png" %}" style="height:50px;width:50px">
                   </div>
                 </div>
                     <div class="col-lg-8">

--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -105,6 +105,19 @@ h2{
     font-size: medium;
 }
 
+/* issue #1239 */
+ul {
+    padding-left: 18px;
+}
+ol.question {
+    list-style-type: decimal;
+    padding-left: 24px;
+}
+ol.answer {
+    list-style-type:lower-alpha;
+    padding-left: 24px;
+}
+
     </style>
     <title>{{ worksheet.module }}</title>
 </head>
@@ -186,10 +199,9 @@ h2{
             <img class="icon-section" src="{{ "img/check.png" | local_static_filepath }}">
         </div>
         <h2>{% trans 'Check your knowledge:' %}</h2>
-    {#  Bullet list with type="1" or type="a" do not work well in the PDF generation. We need a custom counter.  #}
-        <ul style="list-style: none;">
+        <ol class="question" >
             {% for question, answers in questions.items %}
-                <li>{{ forloop.counter }}. {{ question.question }}:
+                <li style="margin-bottom: 0.5em;">{{ question.question }}:
                     {% if question.question_image %}
                         <div>
                         <img id="{{ question.question_image }}"
@@ -198,13 +210,13 @@ h2{
                              style="max-width: 300px !important;"/>
                         </div>
                     {% endif %}
-                <ul style="list-style: none; margin-bottom: 10px;">
+                <ol class="answer">
                     {% for answer in answers %}
-                        <li>{{ forloop.counter | to_char }}. {{ answer.answer }}</li>
+                        <li>{{ answer.answer }}</li>
                     {% endfor %}
-                </ul>
+                </ol>
             {% endfor %}
-        </ul>
+        </ol>
     </section>
 {% endif %}
 


### PR DESCRIPTION
This PR refers to #1239. It does:
- change items list padding to be in line with paragraph content 
- fix overlapping media elements in question section
- change book unicode symbols to book image

![0001](https://user-images.githubusercontent.com/40058076/103338239-b4a3be80-4ab8-11eb-8b51-6cd8ebc42e55.jpg)
![0002](https://user-images.githubusercontent.com/40058076/103338245-b8374580-4ab8-11eb-991d-0da34b8e9138.jpg)
