### PR TITLE
fix minor layout

### DIFF
--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -434,14 +434,6 @@
                 {% endif %}
             </div>
         </div>
-
-        {# funded by  #}
-        <div class="row">
-            <h5 class="text-muted">
-                <p>{{ funded_by|base_markdown }}</p>
-            </h5>
-
-        </div>
     </div>
 
     {# License #}
@@ -479,6 +471,14 @@
     </div>
     {% endif %}
 
+    <div class="container">
+    {# funded by  #}
+        <div class="row">
+            <h5 class="text-muted">
+                <p>{{ funded_by|base_markdown }}</p>
+            </h5>
+        </div>
+    </div>
 
 
     <script>


### PR DESCRIPTION
This PR fixes minor layout in lesson web view, refer to #1253. It does:
- move the "fund by" element to the bottom of page

---
### before

![lesson_fix_web_layout0](https://user-images.githubusercontent.com/40058076/103517025-6faecc00-4eac-11eb-9318-c0633c51434b.png)

### after
![lesson_fix_web_layout1](https://user-images.githubusercontent.com/40058076/103517028-70dff900-4eac-11eb-847f-66355ede2fa7.png)
