### PR TITLE
add pagebreak element in pdf output

### DIFF
--- a/django_project/lesson/models/worksheet.py
+++ b/django_project/lesson/models/worksheet.py
@@ -62,9 +62,9 @@ class Worksheet(TranslationMixin):
 
     summary_text = models.TextField(
         help_text=_('Content of the Summary. Markdown is supported. '
-                    'You can add a pagebreak to the PDF output by inserting '
-                    'a &ltdiv class="page-break"&gt&lt/div&gt element between '
-                    'sections of the content.'),
+                    'Add the following text to insert a page break in the '
+                    'PDF output: a &ltdiv class="page-break"&gt&lt/div&gt '
+                    'element between sections of the content.'),
         blank=False,
         null=False,
     )

--- a/django_project/lesson/models/worksheet.py
+++ b/django_project/lesson/models/worksheet.py
@@ -61,7 +61,10 @@ class Worksheet(TranslationMixin):
     )
 
     summary_text = models.TextField(
-        help_text=_('Content of the summary. Markdown is supported.'),
+        help_text=_('Content of the summary. Markdown is supported. '
+                    'In order to insert a new page in PDF output, add element '
+                    '&ltdiv class="page-break"&gt&lt/div&gt before your '
+                    'content on the new page.'),
         blank=False,
         null=False,
     )

--- a/django_project/lesson/models/worksheet.py
+++ b/django_project/lesson/models/worksheet.py
@@ -61,10 +61,10 @@ class Worksheet(TranslationMixin):
     )
 
     summary_text = models.TextField(
-        help_text=_('Content of the summary. Markdown is supported. '
-                    'In order to insert a new page in PDF output, add element '
-                    '&ltdiv class="page-break"&gt&lt/div&gt before your '
-                    'content on the new page.'),
+        help_text=_('Content of the Summary. Markdown is supported. '
+                    'You can add a pagebreak to the PDF output by inserting '
+                    'a &ltdiv class="page-break"&gt&lt/div&gt element between '
+                    'sections of the content.'),
         blank=False,
         null=False,
     )

--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -118,6 +118,9 @@ ol.answer {
     padding-left: 24px;
 }
 
+.page-break{
+  page-break-before: always;
+}
     </style>
     <title>{{ worksheet.module }}</title>
 </head>


### PR DESCRIPTION
This PR refers to #1240. It does:
- add page break element controller in PDF output
- add page-break element information in help-text model 

![1240_print_controller_element](https://user-images.githubusercontent.com/40058076/103726314-94718380-5013-11eb-9822-8902b534f28a.png)

![1240_print_pdf](https://user-images.githubusercontent.com/40058076/103726319-96d3dd80-5013-11eb-8cc4-bc5936e7ead7.png)
