### PR TITLE
fix GitHub OAuth error

### DIFF
--- a/deployment/docker/REQUIREMENTS.txt
+++ b/deployment/docker/REQUIREMENTS.txt
@@ -27,7 +27,7 @@ django-rosetta==0.9.3
 django-embed-video==1.0.0
 django-grappelli==2.13.2
 pytz
-django-allauth==0.40.0
+django-allauth==0.44.0
 # support special characters
 Unidecode==0.4.20
 Pillow==5.3.0


### PR DESCRIPTION
This PR refers to #1258. It does:
- update django-allauth version to 0.44. To fix error:

```
 File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)
File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  115.                 response = self.process_exception_by_middleware(e, request)
File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py" in _get_response
  113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/usr/local/lib/python3.7/site-packages/allauth/socialaccount/providers/oauth2/views.py" in view
  73.                 return self.dispatch(request, *args, **kwargs)
File "/usr/local/lib/python3.7/site-packages/allauth/socialaccount/providers/oauth2/views.py" in dispatch
  134.                                                 response=access_token)
File "/usr/local/lib/python3.7/site-packages/allauth/socialaccount/providers/github/views.py" in complete_login
  35.             request, extra_data
File "/usr/local/lib/python3.7/site-packages/allauth/socialaccount/providers/base.py" in sociallogin_from_response
  86.         uid = self.extract_uid(response)
File "/usr/local/lib/python3.7/site-packages/allauth/socialaccount/providers/github/provider.py" in extract_uid
  38.         return str(data['id'])
Exception Type: KeyError at /en/accounts/github/login/callback/
Exception Value: 'id'
```