### PR TITLE
Persist section numbering after update the lesson

### DIFF
--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -45,7 +45,7 @@
                             <span class="glyphicon glyphicon-minus"></span>
                         </a>
                         <a class="btn btn-default btn-mini tooltip-toggle"
-                           href='{% url "worksheet-update" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}'
+                           href='{% url "worksheet-update" project_slug=worksheet.section.project.slug section_slug=worksheet.section.slug pk=worksheet.pk %}?q={{ module_number }}'
                            data-title="{% trans 'Edit' %} {{ module }}">
                             <span class="glyphicon glyphicon-pencil"></span>
                         </a>

--- a/django_project/lesson/views/worksheet.py
+++ b/django_project/lesson/views/worksheet.py
@@ -269,6 +269,7 @@ class WorksheetUpdateView(LoginRequiredMixin, WorksheetMixin, UpdateView):
         :rtype: dict
         """
         kwargs = super(WorksheetUpdateView, self).get_form_kwargs()
+        self.numbering = self.request.GET.get('q', '')
         slug = self.kwargs.get('section_slug', None)
         kwargs['section'] = get_object_or_404(Section, slug=slug)
         return kwargs
@@ -282,11 +283,12 @@ class WorksheetUpdateView(LoginRequiredMixin, WorksheetMixin, UpdateView):
         :returns: URL
         :rtype: HttpResponse
         """
-        return reverse('worksheet-detail', kwargs={
+        url = reverse('worksheet-detail', kwargs={
             'pk': self.object.pk,
             'project_slug': self.object.section.project.slug,
             'section_slug': self.object.section.slug,
         })
+        return '%s?q=%s' % (url, self.numbering)
 
 
 class WorksheetDeleteView(


### PR DESCRIPTION
This PR refers to #1257. It does:
- add query string on edit page so that when it's submitted will display the numbering

![changelog_1257_numbering](https://user-images.githubusercontent.com/40058076/104165414-4950d980-5434-11eb-960e-155e9b37c025.gif)
