### PR TITLE
url link for lesson sample data

### DIFF
--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -325,8 +325,8 @@ img.more-about-image {
         <div style="margin-bottom: 10px;padding-top: 10pt;">
             {% if worksheet.external_data %}
                 <p>
-                    {% blocktrans with pk=worksheet.id project_slug=worksheet.section.project.slug href_value=request.META.HTTP_HOST %}
-                      Download the sample data for the lesson from <a target="_blank" href="http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}">http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}</a>.{% endblocktrans %}
+                    {% blocktrans with pk=worksheet.id project_slug=worksheet.section.project.slug module_number=module_number href_value=request.META.HTTP_HOST %}
+                      Download the sample data for the lesson from <a target="_blank" href="http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}?q={{ module_number }}">http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}?q={{ module_number }}</a>.{% endblocktrans %}
                 </p>
             {% endif %}
         </div>

--- a/django_project/lesson/templates/worksheet/print.html
+++ b/django_project/lesson/templates/worksheet/print.html
@@ -325,7 +325,8 @@ img.more-about-image {
         <div style="margin-bottom: 10px;padding-top: 10pt;">
             {% if worksheet.external_data %}
                 <p>
-                    {% blocktrans with url=worksheet.external_data.url href_value=request.META.HTTP_HOST %}Download the sample data for the lesson from <a target="_blank" href="http://{{ href_value }}{{ url }}">http://{{ href_value }}{{ url }}</a>.{% endblocktrans %}
+                    {% blocktrans with pk=worksheet.id project_slug=worksheet.section.project.slug href_value=request.META.HTTP_HOST %}
+                      Download the sample data for the lesson from <a target="_blank" href="http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}">http://{{ href_value }}/{{ project_slug }}/sample/{{ pk }}</a>.{% endblocktrans %}
                 </p>
             {% endif %}
         </div>

--- a/django_project/lesson/tests/test_worksheet_views.py
+++ b/django_project/lesson/tests/test_worksheet_views.py
@@ -242,7 +242,6 @@ class TestViews(TestCase):
                           zip_file.namelist())
             zip_file.close()
 
-
     @override_settings(VALID_DOMAIN=['testserver'])
     def test_download_multiple_worksheets(self):
         self.test_project.name = 'Test project name multiple zip'
@@ -271,3 +270,14 @@ class TestViews(TestCase):
             self.assertIn('1. Section Multiple Download/Test License.txt',
                           zip_file.namelist())
             zip_file.close()
+
+    @override_settings(VALID_DOMAIN=['testserver'])
+    def test_WorksheetSampleData(self):
+        response = self.client.get(reverse(
+            'worksheet-sampledata',
+            kwargs={
+                'project_slug': self.test_section.project.slug,
+                'pk': self.test_worksheet.pk
+            }
+        ))
+        self.assertEqual(response.status_code, 404)

--- a/django_project/lesson/urls.py
+++ b/django_project/lesson/urls.py
@@ -43,6 +43,7 @@ from lesson.views.worksheet import (
     WorksheetModuleQuestionAnswers,
     WorksheetModuleQuestionAnswersPDF,
     WorksheetPDFZipView,
+    WorksheetSampleData,
     download_multiple_worksheet
 )
 from lesson.views.specification import (
@@ -218,6 +219,12 @@ urlpatterns = [
               'delete/(?P<pk>[\w-]+)/$',
         view=AnswerDeleteView.as_view(),
         name='answer-delete'),
+
+    # download a worksheet external data
+    url(regex='^(?P<project_slug>[\w-]+)/sample/(?P<pk>[\w-]+)/$',
+        view=WorksheetSampleData.as_view(),
+        name='worksheet-sampledata'),
+
 ]
 
 # The original urlpatterns below will redirect to urlpatterns above

--- a/django_project/lesson/views/worksheet.py
+++ b/django_project/lesson/views/worksheet.py
@@ -587,6 +587,6 @@ class WorksheetSampleData(View):
             zip_file,
             content_type="application/x-zip-compressed")
         response['Content-Disposition'] = \
-            'attachment; filename="%s%s%s"' % (
+            'attachment; filename=%s%s%s' % (
                 project.name, numbering, extension)
         return response

--- a/django_project/lesson/views/worksheet.py
+++ b/django_project/lesson/views/worksheet.py
@@ -8,13 +8,19 @@ from io import BytesIO
 from collections import OrderedDict
 from django.conf import settings
 from django.urls import reverse
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import (
+    FileResponse,
+    Http404,
+    HttpResponse,
+    HttpResponseRedirect
+)
 from django.views.generic import (
     DetailView,
     CreateView,
     UpdateView,
     DeleteView,
     ListView,
+    View
 )
 from django.shortcuts import get_object_or_404, render_to_response
 from django.utils.translation import ugettext_lazy as _
@@ -564,3 +570,23 @@ def download_multiple_worksheet(request, **kwargs):
         'attachment; filename={}-worksheet {}.zip'.format(
             project.name, downloaded_module)
     return zip_response
+
+
+class WorksheetSampleData(View):
+    """Download sample data."""
+
+    def get(self, request, *args, **kwargs):
+        numbering = self.request.GET.get('q', '')
+        project = get_object_or_404(Project, slug=self.kwargs['project_slug'])
+        worksheet = get_object_or_404(Worksheet, pk=self.kwargs['pk'])
+        zip_file = worksheet.external_data
+        if not zip_file:
+            raise Http404("Sample data does not exist.")
+        name, extension = os.path.splitext(zip_file.name)
+        response = FileResponse(
+            zip_file,
+            content_type="application/x-zip-compressed")
+        response['Content-Disposition'] = \
+            'attachment; filename="%s%s%s"' % (
+                project.name, numbering, extension)
+        return response


### PR DESCRIPTION
This PR refers to #1291.
It provides neater link for download external_data file
`/<project_slug>/sample/<worksheet id>?q=<module number>`

The url cannot use module number as an argument (as mentioned in the ticket), since the module number is not retrieved from the model.
The pdf output name is using project and module number as the filename. 

![image](https://user-images.githubusercontent.com/40058076/108194914-22cc3f80-7152-11eb-8aa1-a1053fc188f3.png)
![image](https://user-images.githubusercontent.com/40058076/108195016-40010e00-7152-11eb-9f2f-f653a933b5d4.png)

