### PR TITLE
Fix dockerfile due to cryptography.io build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 venv
+.venv
 .idea
 *.pyc
 *.*~

--- a/.github/workflows/build-push-images-pr.yaml
+++ b/.github/workflows/build-push-images-pr.yaml
@@ -5,7 +5,7 @@ on:
       - develop
 jobs:
   docker-builder:
-    if: github.event.pull_request.head.repo.fork == 'false'
+    if: github.event.pull_request.base.repo.url == github.event.pull_request.head.repo.url
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+.venv
 .idea
 *.pyc
 *.*~

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -10,6 +10,11 @@ RUN apt-get update -y; apt-get -y --force-yes install yui-compressor gettext
 RUN wget https://github.com/jgm/pandoc/releases/download/1.17.1/pandoc-1.17.1-2-amd64.deb
 RUN dpkg -i pandoc-1.17.1-2-amd64.deb && rm pandoc-1.17.1-2-amd64.deb
 
+# Added because of issue with building cryptography.io using pip
+# This flag disabled rust build, but only for this particular version
+# In the future, we may have to include rust toolchain in the Dockerfile
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
+
 ADD deployment/docker/REQUIREMENTS.txt /REQUIREMENTS.txt
 ADD deployment/docker/uwsgi.conf /uwsgi.conf
 ADD django_project /home/web/django_project


### PR DESCRIPTION
From the build/error log, it shows that for this particular version, we can just follow the instruction and disable rust build toolchain.

Related logs:
https://github.com/kartoza/prj.app/runs/1948774598?check_suite_focus=true#step:7:1411