### PR TITLE
create management command to remove unused media images

### DIFF
--- a/django_project/changes/management/commands/remove_unused_images.py
+++ b/django_project/changes/management/commands/remove_unused_images.py
@@ -2,10 +2,88 @@
 
 import os
 import re
+from django.apps import apps
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
 from changes.models.entry import Entry
+
+
+def get_ImageField_and_ImageField(model):
+    result = []
+    for field in model._meta.fields:
+        if (field.get_internal_type() == 'ImageField'
+                or field.get_internal_type() == 'FileField'):
+            result.append((
+                model._meta.app_label,
+                model.__name__,
+                field.name,
+                field.upload_to
+            ))
+    return result
+
+
+def get_meta_of_models_media():
+    """Get list of all models in app"""
+
+    app_models = [model for model in apps.get_models()]
+
+    # get models which has ImageField or FileField fields
+    media_fields = []
+    for model in app_models:
+        media_fields.extend(get_ImageField_and_ImageField(model))
+    return media_fields
+
+
+def get_all_media():
+    """Scan all unused media
+    """
+
+    image_and_file_files = []  # ImageField and FileField files
+    image_and_file_size = 0  # ImageField and FileField filesize
+
+    all_media_files = []
+    all_media_size = 0
+    media_fields = get_meta_of_models_media()
+    for media in media_fields:
+        app_label, model_name, field_name, upload_to = media
+        # exclude Entry models instance
+        # it's handled in another function
+        if model_name == 'Entry':
+            continue
+        for root, dirs, files in os.walk(os.path.join(
+                settings.MEDIA_ROOT, upload_to)):
+            for name in files:
+                path = os.path.abspath(os.path.join(root, name))
+                # exclude thumbnails
+                if re.match(r'^(?!.*/thumbnails/)', path):
+                    image_path = os.path.join(settings.MEDIA_ROOT, path)
+                    all_media_files.append(image_path)
+                    all_media_size += os.stat(image_path).st_size
+
+        model = apps.get_model(app_label, model_name)  # e.g Worksheet
+        objects = model.objects.all()
+        for obj in objects:
+            # get field
+            field_object = model._meta.get_field(field_name)  # e.g image_file
+            # get field value
+            field_value = field_object.value_from_object(obj)
+            if field_value:
+                file_path = os.path.join(
+                    settings.MEDIA_ROOT, field_value.name
+                )
+                image_and_file_files.append(file_path)
+                try:
+                    image_and_file_size += os.stat(file_path).st_size
+                except FileNotFoundError:
+                    image_and_file_size += 0
+
+    return (
+        image_and_file_files,
+        image_and_file_size,
+        all_media_files,
+        all_media_size,
+    )
 
 
 def get_all_entries_images():
@@ -76,48 +154,90 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
 
+        # get all media exclude Entry
+        (image_and_file_files,
+         image_and_file_size,
+         all_media_files,
+         all_media_size) = get_all_media()
+
+        all_unused_files = []
+        all_unused_files_size = 0
+        for media in all_media_files:
+            if media not in image_and_file_files:
+                all_unused_files.append(media)
+                try:
+                    all_unused_files_size += os.stat(media).st_size
+                except FileNotFoundError:
+                    all_unused_files_size += 0
+
         # get Entry images
         (referenced_github_images,
-         image_field_images,
-         all_media_images,
+         entry_image_field_images,
+         entry_all_media_images,
          github_image_size,
-         image_field_size,
-         all_media_size) = get_all_entries_images()
+         entry_image_field_size,
+         entry_all_media_size) = get_all_entries_images()
 
-        referenced_image = referenced_github_images + image_field_images
-        unused_image = []
-        unused_image_size = 0
-        for image in all_media_images:
+        referenced_image = referenced_github_images + entry_image_field_images
+        entry_unused_image = []
+        entry_unused_image_size = 0
+        for image in entry_all_media_images:
             if image not in referenced_image:
-                unused_image.append(image)
+                entry_unused_image.append(image)
                 try:
-                    unused_image_size += os.stat(image).st_size
+                    entry_unused_image_size += os.stat(image).st_size
                 except FileNotFoundError:
-                    unused_image_size += 0
+                    entry_unused_image_size += 0
 
-        self.stdout.write('-' * 79)
+        self.stdout.write('=' * 79)
+        self.stdout.write('Entry\'s Media')
+        self.stdout.write('-' * 30)
         self.stdout.write(
-            f'GitHub images: {len(referenced_github_images)} files, '
-            f'ImageField images: {len(image_field_images)} files, and '
-            f'All media images: {len(all_media_images)} files.'
+            f'GitHub images: {len(set(referenced_github_images))} files, '
+            f'ImageField images: {len(set(entry_image_field_images))} files, '
+            f'and '
+            f'All media images: {len(set(entry_all_media_images))} files.'
         )
         self.stdout.write(
             f'GitHub images: {round(github_image_size/1000000, 2)} MB, '
-            f'ImageField images: {round(image_field_size/1000000, 2)} MB, '
-            f'All media images: {round(all_media_size/1000000, 2)} MB.'
+            f'ImageField images: {round(entry_image_field_size/1000000, 2)} MB, '
+            f'All media images: {round(entry_all_media_size/1000000, 2)} MB.'
+        )
+        self.stdout.write('\n')
+        self.stdout.write('All Media (exclude Entry model instance)')
+        self.stdout.write('-' * 30)
+        self.stdout.write(
+            f'ImageField and FileField: {len(set(image_and_file_files))} '
+            f'files, '
+            f'All files in the related folder: {len(set(all_media_files))} '
+            f'files.'
+        )
+        self.stdout.write(
+            f'ImageField and FileField: {round(image_and_file_size / 1000000, 2)} MB, '
+            f'All files in the related folder: {round(all_media_size / 1000000, 2)} MB.'
         )
 
         confirmation = input(
-            f'Do you want to delete unused Entry images '
-            f'{len(unused_image)} files, '
-            f'{round(unused_image_size/1000000, 2)} MB? [Y/n] '
+            f'\nDelete unused media images and files: '
+            f'{len(entry_unused_image) + len(all_unused_files)} files, '
+            f'{round((entry_unused_image_size + all_unused_files_size)/1000000, 2)} '
+            f'MB? [Y] '
         )
 
         if confirmation.lower() == 'y':
             self.stdout.write('remove files...')
-            for image in unused_image:
+            for image in entry_unused_image:
                 self.stdout.write(f'remove {image}')
-                os.remove(image)
+                try:
+                    os.remove(image)
+                except FileNotFoundError:
+                    continue
+            for image in all_unused_files:
+                self.stdout.write(f'remove {image}')
+                try:
+                    os.remove(image)
+                except FileNotFoundError:
+                    continue
             self.stdout.write(
                 'All unused Entry images have been removed successfully.'
             )

--- a/django_project/changes/management/commands/remove_unused_images.py
+++ b/django_project/changes/management/commands/remove_unused_images.py
@@ -1,0 +1,126 @@
+"""A command to remove unused media file"""
+
+import os
+import re
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from changes.models.entry import Entry
+
+
+def get_all_entries_images():
+    """Get all images referenced by Entry instance
+
+    There are images downloaded to Media, but not being referenced in
+    ImageFile field instance. The images are referenced by hyperlink saved in
+    description field.
+    """
+
+    all_media_size = 0
+    github_image_size = 0
+    image_field_size = 0
+
+    # get images in images/entries
+    upload_to = os.path.join(settings.MEDIA_ROOT, 'images/entries')
+
+    all_media_images = []  # all images in images/entries
+    for root, dirs, files in os.walk(upload_to):
+        for name in files:
+            path = os.path.abspath(os.path.join(root, name))
+            # exclude thumbnails
+            if re.match(r'^(?!.*/thumbnails/)', path):
+                image_path = os.path.join(settings.MEDIA_ROOT, path)
+                all_media_images.append(image_path)
+                all_media_size += os.stat(image_path).st_size
+
+    entries = Entry.objects.all()
+    referenced_github_images = []  # image referenced in description
+    image_field_images = []  # ImageField's image
+    for entry in entries:
+        if entry.image_file:
+            image_path = os.path.join(
+                settings.MEDIA_ROOT, entry.image_file.name
+            )
+            image_field_images.append(image_path)
+            try:
+                image_field_size += os.stat(image_path).st_size
+            except FileNotFoundError:
+                image_field_size += 0
+                # scan image in entry description
+        # result e.g images/entries/d4ede67e-fd0b-11e6-9de2.png
+        images = re.findall(r'src=".*?(images/entries.*?)"', entry.description)
+        # join path images
+        # e.g /home/web/media/images/entries/d4ede67e-fd0b-11e6-9de2.png
+        for image in images:
+            path = os.path.join(settings.MEDIA_ROOT, image)
+            referenced_github_images.append(path)
+            try:
+                github_image_size += os.stat(path).st_size
+            except FileNotFoundError:
+                github_image_size += 0
+    return (
+        referenced_github_images,
+        image_field_images,
+        all_media_images,
+        github_image_size,
+        image_field_size,
+        all_media_size,
+    )
+
+
+class Command(BaseCommand):
+    help = 'Remove all media that are not referenced by a valid project'
+
+    def add_arguments(self, parser):
+        pass
+
+    def handle(self, *args, **kwargs):
+
+        # get Entry images
+        (referenced_github_images,
+         image_field_images,
+         all_media_images,
+         github_image_size,
+         image_field_size,
+         all_media_size) = get_all_entries_images()
+
+        referenced_image = referenced_github_images + image_field_images
+        unused_image = []
+        unused_image_size = 0
+        for image in all_media_images:
+            if image not in referenced_image:
+                unused_image.append(image)
+                try:
+                    unused_image_size += os.stat(image).st_size
+                except FileNotFoundError:
+                    unused_image_size += 0
+
+        self.stdout.write('-' * 79)
+        self.stdout.write(
+            f'GitHub images: {len(referenced_github_images)} files, '
+            f'ImageField images: {len(image_field_images)} files, and '
+            f'All media images: {len(all_media_images)} files.'
+        )
+        self.stdout.write(
+            f'GitHub images: {round(github_image_size/1000000, 2)} MB, '
+            f'ImageField images: {round(image_field_size/1000000, 2)} MB, '
+            f'All media images: {round(all_media_size/1000000, 2)} MB.'
+        )
+
+        confirmation = input(
+            f'Do you want to delete unused Entry images '
+            f'{len(unused_image)} files, '
+            f'{round(unused_image_size/1000000, 2)} MB? [Y/n] '
+        )
+
+        if confirmation.lower() == 'y':
+            self.stdout.write('remove files...')
+            for image in unused_image:
+                self.stdout.write(f'remove {image}')
+                os.remove(image)
+            self.stdout.write(
+                'All unused Entry images have been removed successfully.'
+            )
+        else:
+            self.stdout.write('remove files aborted!')
+        exit()

--- a/django_project/changes/tests/test_remove_unused_images.py
+++ b/django_project/changes/tests/test_remove_unused_images.py
@@ -1,0 +1,53 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from changes.management.commands.remove_unused_images import \
+    get_all_entries_images
+from base.tests.model_factories import ProjectF
+from changes.tests.model_factories import (
+    CategoryF,
+    VersionF)
+from core.model_factories import UserF
+from changes.models import Entry
+
+
+class TestGetAllEntriesImage(TestCase):
+    def setUp(self) -> None:
+        gif_byte = (
+            b'\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\x05\x04'
+            b'\x04\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02'
+            b'\x02\x44\x01\x00\x3b'
+        )
+        image_uploaded = SimpleUploadedFile(
+            'gif.gif', gif_byte, content_type='image/gif')
+        self.project = ProjectF.create()
+        self.category = CategoryF.create(project=self.project)
+        self.version = VersionF.create(project=self.project)
+        self.user = UserF.create(**{
+            'username': 'suman',
+            'password': 'password',
+            'is_staff': True
+        })
+        self.entry = Entry.objects.create(
+            version=self.version,
+            category=self.category,
+            author=self.user,
+            title='Test remove unused images.',
+            image_file=image_uploaded,
+            description=(
+                '<h2>Description</h2><p><img  '
+                'src="/media/images/entries/75693398-2ba8d480-5ca7-11ea-8be0-'
+                '9643f8841c89-2.png" /><img  src="/media/images/entries/'
+                '75693404-2d729800-5ca7-11ea-889d-5aa73bc131ce-1.png" /></p>')
+        )
+
+    def test_get_all_entries_images(self):
+        (referenced_github_images,
+         image_field_images,
+         all_media_images,
+         github_image_size,
+         image_field_size,
+         all_media_size) = get_all_entries_images()
+
+        self.assertEqual(len(referenced_github_images), 2)
+        self.assertEqual(len(image_field_images), 1)


### PR DESCRIPTION
This PR refers to #1319.

For now, this only delete unused image related to Entry model instance.

```
root@22ac3a8f9c47:/home/web/django_project# ./manage.py remove_unused_images
-------------------------------------------------------------------------------
GitHub images: 71 files, ImageField images: 945 files, and All media images: 1763 files.
GitHub images: 15.49 MB, ImageField images: 387.49 MB, All media images: 701.42 MB.
Do you want to delete unused Entry images 840 files, 314.45 MB? [Y/n] y
remove files...
remove /home/web/media/images/entries/72318360-cd6c6600-36e7-11ea-9f2d-9a47d8772623.gif
.
.
All unused Entry images have been removed successfully.
```