### PR TITLE
fix typo download_multiple_files

### DIFF
--- a/django_project/lesson/static/js/download_multiple_files.js
+++ b/django_project/lesson/static/js/download_multiple_files.js
@@ -30,7 +30,7 @@ function getWorksheetListPage(){
     const urlParams = new URLSearchParams(window.location.search);
     var page = urlParams.get('page');
     if (page == null){
-        page = "1"change
+        page = "1"
     }
     var $checkedElements = $('.worksheet-checkbox:checked');
     var worksheets = {};


### PR DESCRIPTION
It fixes error download multiple files:
![image](https://user-images.githubusercontent.com/40058076/111964792-f54b2b00-8b2f-11eb-89f4-0ef5eac6e942.png)
