### PR TITLE
Allow "sponsored by" when parsing PR description

### DIFF
--- a/django_project/changes/tests/test_github_pull_request.py
+++ b/django_project/changes/tests/test_github_pull_request.py
@@ -122,6 +122,20 @@ class TestGithubPullRequest(unittest.TestCase):
         self.assertEqual('myself.inc', funded_by)
         self.assertEqual('https://myself.me', url)
 
+        # Switch to "sponsored by", with markdown and capital letters,
+        body = (
+            'This is a new feature :\n\n'
+            '* SPONSORED BY myself.inc https://myself.me\n'
+            '* IT\n'
+            '* WILL\n'
+            '* ROCK'
+        )
+        content, funded_by, url = parse_funded_by(body)
+        self.assertEqual(
+            'This is a new feature :\n\n* IT\n* WILL\n* ROCK', content)
+        self.assertEqual('myself.inc', funded_by)
+        self.assertEqual('https://myself.me', url)
+
         # No name, only URL
         body = (
             'This is a new feature :\n'

--- a/django_project/changes/utils/github_pull_request.py
+++ b/django_project/changes/utils/github_pull_request.py
@@ -8,8 +8,8 @@ def parse_funded_by(content: str) -> tuple:
 
     It returns the content but without the funder in it if was found.
     """
-    token = 'funded by'
-    funded_regex = r'^{}'.format(token)
+    token = ('funded by', 'sponsored by')
+    funded_regex = r'^{}'.format('|'.join(token))
     url_regex = r'(https?://\S+)'
 
     new_content = []


### PR DESCRIPTION
Allow "sponsored by" when parsing PR description