### PR TITLE
Set embedded youtube player aspect ratio to 16:9

### DIFF
--- a/django_project/lesson/templates/worksheet/detail.html
+++ b/django_project/lesson/templates/worksheet/detail.html
@@ -101,6 +101,7 @@
         <div class="row text-center">
             <!-- The video tag: -->
             {% video worksheet.youtube_link as youtube %}
+              <!-- Video aspect ratio 16:9 -->
               {% video youtube "large" %}
             {% endvideo %}
         </div>
@@ -698,5 +699,20 @@
                 $(this).find('.further-reading-action').hide();
             }
         );
+
+        // video aspect ratio must be 16:9
+        function videoAspect(){
+          let videoWidth = $('div.body-content').css('width').match(/[0-9]+/g)[0];
+          let videoUnit = $("div.body-content").css('width').match(/[a-zA-Z]+/g)[0];
+          videoWidth = parseInt(videoWidth);
+
+          let ratio = 16/9;
+          let videoHeight = Math.floor(videoWidth / ratio);
+          $('iframe').css('width', videoWidth + videoUnit);
+          $('iframe').css('height', videoHeight + videoUnit);
+        }
+
+        $('iframe').load(videoAspect)
+        $(window).on('resize', videoAspect)
     </script>
 {% endblock %}


### PR DESCRIPTION
This is to address #1331 

![1331_youtube](https://user-images.githubusercontent.com/40058076/118445852-83ebbb00-b721-11eb-80c1-290c662332d9.gif)
