### PR TITLE
Fix dockerfile and documentation for dev env

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -33,9 +33,9 @@ When it's done, you can continue with this command:
 Linux and MacOS:
 
 ```
+cp docker-compose.override.example.yml docker-compose.override.yml
 make build-devweb
 make devweb
-cp docker-compose.override.example.yml docker-compose.override.yml
 ```
 
 In case you don't get some not installed packages, you can run this 
@@ -54,6 +54,7 @@ repeatable steps:
 Windows:
 
 ```
+copy docker-compose.override.example.yml docker-compose.override.yml
 make-devbuild.bat
 make-devweb.bat
 ```

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Tim Sutton<tim@kartoza.com>
 #RUN  ln -s /bin/true /sbin/initctl
 
 # Pandoc needed to generate rst dumps, uic compressor needed for django-pipeline
-RUN apt-get update -y; apt-get -y --force-yes install yui-compressor gettext
+RUN apt-get update -y && apt-get -y --force-yes install yui-compressor gettext
 RUN wget https://github.com/jgm/pandoc/releases/download/1.17.1/pandoc-1.17.1-2-amd64.deb
 RUN dpkg -i pandoc-1.17.1-2-amd64.deb && rm pandoc-1.17.1-2-amd64.deb
 
@@ -18,7 +18,7 @@ ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 ADD deployment/docker/REQUIREMENTS.txt /REQUIREMENTS.txt
 ADD deployment/docker/uwsgi.conf /uwsgi.conf
 ADD django_project /home/web/django_project
-RUN pip install -r /REQUIREMENTS.txt
+RUN pip install --upgrade pip && pip install -r /REQUIREMENTS.txt
 RUN pip install uwsgi
 
 
@@ -50,7 +50,7 @@ RUN echo "export VISIBLE=now" >> /etc/profile
 # End of cut & paste section
 
 ADD deployment/docker/REQUIREMENTS-dev.txt /REQUIREMENTS-dev.txt
-RUN pip install -r /REQUIREMENTS-dev.txt
+RUN pip install --upgrade pip && pip install -r /REQUIREMENTS-dev.txt
 ADD deployment/docker/bashrc /root/.bashrc
 
 # --------------------------------------------------------


### PR DESCRIPTION
### Problem
Recently when build on local (dev env), it returns error during installing requirements. 
Update: build also failed in current develop branch : https://github.com/kartoza/prj.app/actions/runs/1498405746

Error message:

```
...
 This package requires Rust >=1.41.0.
#13 191.0   
#13 191.0   ----------------------------------------
#13 191.0   Failed building wheel for cryptography
#13 191.0   Running setup.py clean for cryptography
#13 195.0   Complete output from command /usr/local/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-t4pokvxu/cryptography/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" clean --all:
#13 195.0   running clean
#13 195.0   removing 'build/lib.linux-x86_64-3.7' (and everything under it)
#13 195.0   'build/bdist.linux-x86_64' does not exist -- can't clean it
#13 195.0   'build/scripts-3.7' does not exist -- can't clean it
#13 195.0   removing 'build'
#13 195.0   running clean_rust
#13 195.0   
#13 195.0       =============================DEBUG ASSISTANCE=============================
#13 195.0       If you are seeing a compilation error please try the following steps to
#13 195.0       successfully install cryptography:
#13 195.0       1) Upgrade to the latest pip and try again. This will fix errors for most
#13 195.0          users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
#13 195.0       2) Read https://cryptography.io/en/latest/installation/ for specific
#13 195.0          instructions for your platform.
#13 195.0       3) Check our frequently asked questions for more information:
#13 195.0          https://cryptography.io/en/latest/faq/
#13 195.0       4) Ensure you have a recent Rust toolchain installed:
#13 195.0          https://cryptography.io/en/latest/installation/#rust
#13 195.0   
#13 195.0       Python: 3.7.2
#13 195.0       platform: Linux-5.10.47-linuxkit-x86_64-with-debian-9.6
#13 195.0       pip: 18.1
#13 195.0       setuptools: 59.2.0
#13 195.0       setuptools_rust: 1.0.0
#13 195.0       =============================DEBUG ASSISTANCE=============================
#13 195.0   
#13 195.0   error: can't find Rust compiler
#13 195.0   
#13 195.0   If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
#13 195.0   
#13 195.0   To update pip, run:
#13 195.0   
#13 195.0       pip install --upgrade pip
#13 195.0   
#13 195.0   and then retry package installation.
...
```

### Proposed Solution
- Update Dockerfile: add ` pip install --upgrade pip` as suggested in the error mesage