### PR TITLE
Fix raising ValidationError in validate_email_address

### DIFF
--- a/django_project/certification/models/certifying_organisation.py
+++ b/django_project/certification/models/certifying_organisation.py
@@ -71,10 +71,11 @@ def validate_email_address(value):
     try:
         validate_email(value)
         return True
-    except ValidationError(
+    except ValidationError:
+        raise ValidationError(
             _('%(value)s is not a valid email address'),
-            params={'value': value},):
-        return False
+            params={'value': value},
+        )
 
 
 class CertifyingOrganisation(models.Model):

--- a/django_project/certification/tests/test_models.py
+++ b/django_project/certification/tests/test_models.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 """Test for models."""
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from certification.tests.model_factories import (
     CertificateF,
@@ -415,3 +416,15 @@ class TestStatus(TestCase):
         for key, val in new_model_data.items():
             self.assertEqual(model.__dict__.get(key), val)
             self.assertTrue(model.name == 'new Status name')
+
+
+class TestValidateEmailAddress(TestCase):
+    """Test validate_email_address function."""
+
+    def test_validation_failed_must_raise_ValidationError(self):
+        from certification.models import validate_email_address
+        email = 'email@wrongdomain'
+        msg = f'{email} is not a valid email address'
+        with self.assertRaisesMessage(ValidationError, msg):
+            validate_email_address(email)
+

--- a/django_project/certification/tests/test_models.py
+++ b/django_project/certification/tests/test_models.py
@@ -427,4 +427,3 @@ class TestValidateEmailAddress(TestCase):
         msg = f'{email} is not a valid email address'
         with self.assertRaisesMessage(ValidationError, msg):
             validate_email_address(email)
-

--- a/django_project/changes/models/sponsor.py
+++ b/django_project/changes/models/sponsor.py
@@ -38,10 +38,11 @@ def validate_email_address(value):
     try:
         validate_email(value)
         return True
-    except ValidationError(
+    except ValidationError:
+        raise ValidationError(
             _('%(value)s is not a valid email address'),
-            params={'value': value},):
-        return False
+            params={'value': value},
+        )
 
 
 class ApprovedSponsorManager(models.Manager):

--- a/django_project/changes/tests/test_models.py
+++ b/django_project/changes/tests/test_models.py
@@ -1,7 +1,10 @@
 # coding=utf-8
 """Tests for models."""
 from datetime import datetime
+
+from django.core.exceptions import ValidationError
 from django.test import TestCase
+
 from changes.tests.model_factories import (
     CategoryF,
     EntryF,
@@ -460,3 +463,14 @@ class TestSponsorshipPeriodCRUD(TestCase):
 
         # check if deleted
         self.assertTrue(model.pk is None)
+
+
+class TestValidateEmailAddress(TestCase):
+    """Test validate_email_address function."""
+
+    def test_validation_failed_must_raise_ValidationError(self):
+        from changes.models import validate_email_address
+        email = 'email@wrongdomain'
+        msg = f'{email} is not a valid email address'
+        with self.assertRaisesMessage(ValidationError, msg):
+            validate_email_address(email)


### PR DESCRIPTION
Please see #1372. 

There was return 500 when user updated information in `Update Sustaining Member` page. After replicated the issue, I found that  fixing the way we raise ValidationError in validate_email_address will resolve this issue

![image](https://user-images.githubusercontent.com/40058076/143551769-15bd41e6-ed3f-4396-a779-0f81ede9bdef.png)
