### PR TITLE
Reduce logging file size in docker containers

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -54,6 +54,11 @@ services:
       - db:db
     restart: unless-stopped
     user: root
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
 
   dbbackups:
     image: kartoza/pg-backup:9.6

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -90,6 +90,11 @@ services:
     links:
       - uwsgi:uwsgi
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "10"
 
   # This is the entry point for a development server.
   # Run with --no-deps to run attached to the services


### PR DESCRIPTION
Please see #1369

Problem: logging files have big filesize json

e.g:
```
-rw-r----- 1 root root 1.3G Jan  2 06:08 [#####]/e95bb7b21a91a9aa5db9c6330a8e52b93ca00f13904d31fc261362bcbbf3bbff-json.log
-rw-r----- 1 root root 909M Jan  2 06:08 [#####]/c04d57da8655a21080667e9ddfee5e40775d1d7e3da6a519c9516254118a5343-json.log
```


Proposed solution:
Reduce the container log to avoid running out of disk space. 