### PR TITLE
Fix certificate type view permission

### DIFF
--- a/django_project/certification/tests/views/test_certificate_type_view.py
+++ b/django_project/certification/tests/views/test_certificate_type_view.py
@@ -26,17 +26,28 @@ class TestCertificateTypesView(TestCase):
         self.user = UserF.create(**{
             'username': 'tester',
             'password': 'password',
+            'is_staff': False,
+        })
+
+        self.user_manager = UserF.create(**{
+            'username': 'manager',
+            'password': 'password',
+            'is_staff': False,
+        })
+        self.project.certification_managers.add(self.user_manager)
+
+        self.user_staff = UserF.create(**{
+            'username': 'staff',
+            'password': 'password',
             'is_staff': True,
         })
-        self.user.set_password('password')
-        self.user.save()
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_certificate_type_view_contains_course_type(self):
         """Test CertificateType list page."""
 
         self.client.post('/set_language/', data={'language': 'en'})
-        self.client.login(username='tester', password='password')
+        self.client.force_login(self.user_staff)
         url = reverse('certificate-type-list', kwargs={
             'project_slug': self.project.slug
         })
@@ -55,9 +66,29 @@ class TestCertificateTypesView(TestCase):
         )
 
     @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_certificate_type_user_is_manager(self):
+        self.client.post('/set_language/', data={'language': 'en'})
+        self.client.force_login(self.user_manager)
+        url = reverse('certificate-type-list', kwargs={
+            'project_slug': self.project.slug
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_certificate_type_non_manager_should_return404(self):
+        self.client.post('/set_language/', data={'language': 'en'})
+        self.client.force_login(self.user)
+        url = reverse('certificate-type-list', kwargs={
+            'project_slug': self.project.slug
+        })
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
     def test_update_project_certificate_view(self):
         self.client.post('/set_language/', data={'language': 'en'})
-        self.client.login(username='tester', password='password')
+        self.client.force_login(self.user_staff)
         url = reverse('certificate-type-update', kwargs={
             'project_slug': self.project.slug
         })
@@ -68,3 +99,35 @@ class TestCertificateTypesView(TestCase):
         soup = Soup(response.content, "html5lib")
         self.assertTrue(len(soup.find_all('input', checked=True)) == 1)
         self.assertEqual(soup.find('input', checked=True)["value"], "type-2")
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_update_project_certificate_view_user_is_manager(self):
+        self.client.post('/set_language/', data={'language': 'en'})
+        self.client.force_login(self.user_manager)
+        url = reverse('certificate-type-update', kwargs={
+            'project_slug': self.project.slug
+        })
+        # choose certificate type-2 only
+        post_data = {'certificate_types': 'type-2'}
+        response = self.client.post(url, data=post_data, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_update_project_certificate_non_manager_should_return404(self):
+        self.client.post('/set_language/', data={'language': 'en'})
+        self.client.force_login(self.user)
+        url = reverse('certificate-type-update', kwargs={
+            'project_slug': self.project.slug
+        })
+        # choose certificate type-2 only
+        post_data = {'certificate_types': 'type-2'}
+        response = self.client.post(url, data=post_data, follow=True)
+        self.assertRedirects(
+            response,
+            expected_url=reverse(
+                'certificate-type-list',
+                kwargs={'project_slug': self.project.slug}
+            ),
+            status_code=302,
+            target_status_code=404
+        )

--- a/django_project/certification/views/certificate_type.py
+++ b/django_project/certification/views/certificate_type.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import ListView
@@ -14,6 +14,17 @@ class ProjectCertificateTypeView(LoginRequiredMixin, ListView):
     context_object_name = 'project_certificate_types'
     template_name = 'certificate_type/list.html'
     model = ProjectCertificateType
+
+    def dispatch(self, request, *args, **kwargs):
+        """Ensure user has permission to access this view."""
+        project = get_object_or_404(Project, slug=self.kwargs['project_slug'])
+        manager = project.certification_managers.all()
+        if not request.user.is_staff and request.user not in manager:
+            raise Http404('Sorry! You have to be staff or certification '
+                          'manager to open this page.')
+        return super(ProjectCertificateTypeView, self).dispatch(
+            request, *args, **kwargs
+        )
 
     def get_context_data(self, **kwargs):
         """Get the context data which is passed to a template."""


### PR DESCRIPTION
Please see: #1402 

Problem: 
Normal user can access the certificate type via url

Proposed solution:
Check if user is `staff` or `certification manager` in dispatch method