### PR TITLE
Limit trained_competence to 120 characters

### DIFF
--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -370,9 +370,15 @@ class CourseForm(forms.ModelForm):
     # Override the `trained_competence` field to add a character limit
     trained_competence = forms.CharField(
         max_length=120,
-        help_text='Trained competence e.g. Plugin development (max 120 characters).',
-        widget=forms.TextInput(attrs={'class': 'form-control', 'maxlength': '120'}),
+        help_text=(
+            'Trained competence e.g. Plugin development '
+            '(max 120 characters).'
+        ),
+        widget=forms.TextInput(
+            attrs={'class': 'form-control', 'maxlength': '120'}
+        ),
     )
+
     class Meta:
         model = Course
         fields = (

--- a/django_project/certification/forms.py
+++ b/django_project/certification/forms.py
@@ -367,6 +367,12 @@ class TrainingCenterForm(geoforms.ModelForm):
 class CourseForm(forms.ModelForm):
 
     # noinspection PyClassicStyleClass.
+    # Override the `trained_competence` field to add a character limit
+    trained_competence = forms.CharField(
+        max_length=120,
+        help_text='Trained competence e.g. Plugin development (max 120 characters).',
+        widget=forms.TextInput(attrs={'class': 'form-control', 'maxlength': '120'}),
+    )
     class Meta:
         model = Course
         fields = (

--- a/django_project/certification/views/certificate.py
+++ b/django_project/certification/views/certificate.py
@@ -366,7 +366,7 @@ def generate_pdf(
         center, 300, 'With a trained competence in:')
     page.setFont('Noto-Bold', 14)
     page.drawCentredString(
-        center, 280, '{}'.format(course.trained_competence))
+        center, 280, '{}'.format(course.trained_competence[:120]))
     page.setFont('Noto-Regular', 16)
     page.drawCentredString(
         center, 250, '{}'.format(course_duration))


### PR DESCRIPTION
Fix for #1366 

I think it's better to limit the character from the form instead of adjusting the max_length directly in the model to avoid changing the existing data.

For existing courses with `Trained competence` that exceed the limit of 120 characters, an error will be raised when updating the form:

![image](https://github.com/user-attachments/assets/d2c22bb3-53f1-4a10-9282-6e8369018579)

I've also directly truncated this attribute in the certificate to avoid issues like #1366 for the existing course, so the user will also see that it doesn't fit and needs to be updated.