### PR TITLE
Auto reject organisation

### DIFF
--- a/django_project/certification/management/commands/reject_pending_organisations.py
+++ b/django_project/certification/management/commands/reject_pending_organisations.py
@@ -5,15 +5,6 @@ from ...models.certifying_organisation import CertifyingOrganisation
 from ...models.status import Status
 from ...views import send_rejection_email
 
-# coding=utf-8
-"""Command to reject pending
-certifying organisations that were
-created more than one year ago.
-This command sets the status
-of these organisations to Rejected.
-
-"""
-
 
 class Command(BaseCommand):
     """Reject pending certifying organisations

--- a/django_project/certification/management/commands/reject_pending_organisations.py
+++ b/django_project/certification/management/commands/reject_pending_organisations.py
@@ -1,0 +1,67 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from datetime import timedelta
+from ...models.certifying_organisation import CertifyingOrganisation
+from ...models.status import Status
+from ...views import send_rejection_email
+
+# coding=utf-8
+"""Command to reject pending
+certifying organisations that were
+created more than one year ago.
+This command sets the status
+of these organisations to Rejected.
+
+"""
+
+
+class Command(BaseCommand):
+    """Reject pending certifying organisations
+    that were created more than one year ago
+    and set their status to Rejected.
+
+    """
+
+    help = 'Reject pending certifying organisations\
+          that were created more than one year ago \
+            and set their status to Rejected.'
+
+    def add_arguments(self, parser):
+        # Adding a custom argument for the number of days
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=356,
+            help='Number of days from now to filter records for update.'
+        )
+
+    def handle(self, *args, **options):
+        print('Begin process....')
+        days = options.get('days')
+        print(f'Number of days: {days}')
+        one_year_ago = timezone.now() - timedelta(days=days)
+        old_organisations = CertifyingOrganisation.unapproved_objects.all()
+
+        print('Begin process to reject old certifying organisations.')
+
+        count = 0
+        for organisation in old_organisations:
+            if organisation.creation_date < one_year_ago:
+                rejected_status, created = Status.objects.get_or_create(
+                    name='Rejected',
+                    project=organisation.project
+                )
+                organisation.status = rejected_status
+                organisation.rejected = True
+                organisation.save()
+
+                send_rejection_email(
+                    organisation,
+                    'changelog.qgis.org',
+                    'https'
+                )
+                count += 1
+                print(f'{organisation.name} has been set to Rejected')
+        print(f'{count} certifying organisations has been set to Rejected')
+        print('------------------------------------------------------------')
+        print('Process finished.')

--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -434,3 +434,15 @@ class TestCertifyingOrganisationView(TestCase):
         self.assertEquals(self.certifying_organisation.status.name, 'Approved')
         self.assertEquals(
             self.pending_certifying_organisation.status.name, 'Pending')
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_auto_reject_command(self):
+        out = StringIO()
+        call_command('reject_pending_organisations', '--days=0', stdout=out)
+        self.certifying_organisation.refresh_from_db()
+        self.pending_certifying_organisation.refresh_from_db()
+        self.assertEquals(
+            self.pending_certifying_organisation.status.name, 'Rejected'
+        )
+        self.assertTrue(
+            self.pending_certifying_organisation.rejected)


### PR DESCRIPTION
Fix for #1390 

- Added a command that rejects pending organisations older than one year
- Need to add the following cronjob: `0 0 * * * cd ~/prj.app/deployment && docker compose exec devweb python manage.py reject_pending_organisations`

I think it would be better to use celery later when we apply the stack upgrade. For now, it's more suitable to set it as a cronjob. 