### PR TITLE
Only allow positive numbers in the credits input

### DIFF
--- a/django_project/certification/templates/certificate/top_up.html
+++ b/django_project/certification/templates/certificate/top_up.html
@@ -39,8 +39,15 @@
                 <div class="form-group">
                     <div class="form-group">
                         <label for="creditAmount">Credits</label>
-                        <input type="number" class="form-control"
-                               id="creditAmount" placeholder="Credits" name="total-credits">
+                        <input 
+                            type="number" 
+                            class="form-control"
+                            id="creditAmount" 
+                            placeholder="Credits" 
+                            name="total-credits" 
+                            min="0" 
+                            oninput="this.value = this.value.replace(/[^0-9]/g, '');"
+                        >
                     </div>
                 </div>
                 <div class="payment-container">


### PR DESCRIPTION
Fix for #1456 

- Set the minimum allowed value to 1
- Only numbers are allowed to be typed in the input, typing any other characters won't have any effect.

https://github.com/user-attachments/assets/cca5f0d7-4393-453d-873a-e19eb8b97a11

