### PR TITLE
Show the pending orgs list for staff only

### DIFF
--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -43,6 +43,14 @@ class TestCertifyingOrganisationView(TestCase):
         })
         self.user.set_password('password')
         self.user.save()
+        self.simple_user = UserF.create(**{
+            'username': 'user',
+            'password': 'password',
+            'is_staff': False
+        })
+        
+        self.simple_user.set_password('password')
+        self.simple_user.save()
         self.project = ProjectF.create()
         self.certifying_organisation = CertifyingOrganisationF.create(
             project=self.project
@@ -85,6 +93,17 @@ class TestCertifyingOrganisationView(TestCase):
                     }) + '?ready=false')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['pending'], True)
+
+    @override_settings(VALID_DOMAIN=['testserver', ])
+    def test_list_pending_view_non_staff(self):
+        client = Client()
+        client.login(username='user', password='password')
+        response = client.get(
+            reverse('pending-certifyingorganisation-list',
+                    kwargs={
+                        'project_slug': self.project.slug
+                    }) + '?ready=false')
+        self.assertEqual(response.status_code, 403)
 
     @override_settings(VALID_DOMAIN=['testserver', ])
     def test_list_pending_json(self):

--- a/django_project/certification/tests/views/test_certifying_organisation_views.py
+++ b/django_project/certification/tests/views/test_certifying_organisation_views.py
@@ -48,7 +48,7 @@ class TestCertifyingOrganisationView(TestCase):
             'password': 'password',
             'is_staff': False
         })
-        
+
         self.simple_user.set_password('password')
         self.simple_user.save()
         self.project = ProjectF.create()

--- a/django_project/certification/views/certifying_organisation.py
+++ b/django_project/certification/views/certifying_organisation.py
@@ -23,7 +23,10 @@ from django.views.generic import (
 from django.http import HttpResponseRedirect, Http404
 from django.db import IntegrityError
 from django.core.exceptions import ValidationError
-from braces.views import LoginRequiredMixin, UserPassesTestMixin, StaffuserRequiredMixin
+from braces.views import (
+    LoginRequiredMixin,
+    UserPassesTestMixin,
+    StaffuserRequiredMixin)
 from django_datatables_view.base_datatable_view import BaseDatatableView
 from django.contrib.sessions.models import Session
 from pure_pagination.mixins import PaginationMixin
@@ -99,7 +102,10 @@ class CustomStaffuserRequiredMixin(StaffuserRequiredMixin):
                 CustomStaffuserRequiredMixin, self).no_permissions_fail(
                 request)
 
-        return HttpResponse('Sorry! You do not have permission to perform this action.', status=403)
+        return HttpResponse(
+            'Sorry! You do not have permission to perform this action.',
+            status=403
+        )
 
 
 class CertifyingOrganisationMixin(object):

--- a/django_project/core/base_templates/includes/base-auth-nav-left.html
+++ b/django_project/core/base_templates/includes/base-auth-nav-left.html
@@ -185,8 +185,10 @@
                 <li><a href="{% url 'about' the_project.slug %}">Learn about Certification</a></li>
                 <li><a href="{% url 'certifyingorganisation-create' the_project.slug %}">{% trans 'Sign Up for Certification!' %}</a></li>
                 <li><a href="{% url 'certifyingorganisation-list' the_project.slug %}">Approved Organisations</a></li>
-                <li><a href="{% url 'pending-certifyingorganisation-list' the_project.slug %}?ready=False">Pending Organisations</a></li>
-                <li><a href="{% url 'pending-certifyingorganisation-list' the_project.slug %}?ready=True">Pending Organisations - Ready</a></li>
+                {% if user.is_staff %}
+                    <li><a href="{% url 'pending-certifyingorganisation-list' the_project.slug %}?ready=False">Pending Organisations</a></li>
+                    <li><a href="{% url 'pending-certifyingorganisation-list' the_project.slug %}?ready=True">Pending Organisations - Ready</a></li>
+                {% endif %}
                 <li><a href="{% url 'validate-certificate-organisation' the_project.slug %}">Verify certificate for Certifying Organisation</a></li>
                 <li><a href="{% url 'validate-certificate' the_project.slug %}">Verify certificate for Attendee</a></li>
                 {% if user.is_staff or user in the_project.certification_managers.all %}


### PR DESCRIPTION
Fix for #1441 

- Hide the pending organisations' menu entries in the top bar for normal users
- Return an unauthorized page when a normal user navigates to the pending organisations' page
- Update unit tests